### PR TITLE
chore: enable permalinks for TOC

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -69,6 +69,8 @@ markdown_extensions:
   - attr_list
   - footnotes
   - md_in_html
+  - toc:
+      permalink: true
   - pymdownx.snippets
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=permalink#table-of-contents