### PR TITLE
feat: add flag for marking migrated clients

### DIFF
--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/Lokksmith.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/Lokksmith.kt
@@ -8,6 +8,7 @@ import dev.lokksmith.client.ClientImpl
 import dev.lokksmith.client.asId
 import dev.lokksmith.client.asKey
 import dev.lokksmith.client.snapshot.Snapshot
+import dev.lokksmith.client.snapshot.migrate
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -108,7 +109,7 @@ public class Lokksmith internal constructor(
             coroutineScope = container.coroutineScope,
             snapshotStore = container.snapshotStore,
             provider = container.clientProviderFactory(),
-        )
+        ).migrate()
     }
 
     /**

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -547,7 +547,7 @@ internal class ClientImpl private constructor(
             coroutineScope: CoroutineScope,
             snapshotStore: SnapshotStore,
             provider: Provider,
-        ): Client {
+        ): InternalClient {
             // Create a "child" CoroutineScope that can be cancelled individually per client
             val clientCoroutineScope = CoroutineScope(
                 coroutineScope.coroutineContext

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/jwt/JwtEncoder.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/jwt/JwtEncoder.kt
@@ -8,7 +8,7 @@ import kotlin.io.encoding.Base64.PaddingOption
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 internal class JwtEncoder(
-    private val json: Json,
+    private val serializer: Json,
 ) {
 
     /**
@@ -16,7 +16,7 @@ internal class JwtEncoder(
      */
     @OptIn(ExperimentalEncodingApi::class)
     fun encode(jwt: Jwt): String {
-        val headerJson = json.encodeToString(jwt.header)
+        val headerJson = serializer.encodeToString(jwt.header)
         val header = Base64.UrlSafe.withPadding(PaddingOption.ABSENT).encode(
             headerJson.encodeToByteArray()
         )
@@ -27,11 +27,11 @@ internal class JwtEncoder(
          *
          * @see JwtPayloadExtraTransformingSerializer
          */
-        val intermediatePayload = json.encodeToJsonElement(
+        val intermediatePayload = serializer.encodeToJsonElement(
             JwtPayloadExtraTransformingSerializer(),
-            json.encodeToJsonElement(jwt.payload) as JsonObject
+            serializer.encodeToJsonElement(jwt.payload) as JsonObject
         )
-        val payloadJson = json.encodeToString(intermediatePayload)
+        val payloadJson = serializer.encodeToString(intermediatePayload)
         val payload = Base64.UrlSafe.withPadding(PaddingOption.ABSENT).encode(
             payloadJson.encodeToByteArray()
         )

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
@@ -5,12 +5,14 @@ import dev.lokksmith.client.Id
 import dev.lokksmith.client.Key
 import kotlinx.serialization.Serializable
 
+internal const val CURRENT_SCHEMA_VERSION = 2
+
 /**
  * A [Snapshot] represents the persistable state of a [Client].
  */
 @Serializable
 public data class Snapshot(
-    val schemaVersion: Int = 1,
+    val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
     val key: Key,
     val id: Id,
     val metadata: Client.Metadata,
@@ -39,6 +41,11 @@ public data class Snapshot(
      * Holds temporary data that is required to fulfill an auth request.
      */
     val ephemeralFlowState: EphemeralFlowState? = null,
+
+    /**
+     * Flag that denotes if the client was migrated via [dev.lokksmith.client.Migration].
+     */
+    val migrated: Boolean = false,
 ) {
 
     @Serializable

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/SnapshotMigration.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/SnapshotMigration.kt
@@ -1,0 +1,27 @@
+package dev.lokksmith.client.snapshot
+
+import dev.lokksmith.client.InternalClient
+
+internal object SnapshotMigration {
+
+    suspend fun migrate(client: InternalClient): InternalClient {
+        if (client.snapshots.value.schemaVersion == CURRENT_SCHEMA_VERSION) return client
+
+        client.updateSnapshot {
+            migrateSnapshot(this)
+        }
+
+        return client
+    }
+
+    private fun migrateSnapshot(snapshot: Snapshot): Snapshot {
+        if (snapshot.schemaVersion == 1) {
+            // No migration required except updating the schema version
+            return snapshot.copy(schemaVersion = CURRENT_SCHEMA_VERSION)
+        }
+        return snapshot
+    }
+}
+
+internal suspend fun InternalClient.migrate(): InternalClient =
+    SnapshotMigration.migrate(this)

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/MigrationTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/MigrationTest.kt
@@ -1,0 +1,110 @@
+package dev.lokksmith.client
+
+import dev.lokksmith.client.jwt.Jwt
+import dev.lokksmith.client.jwt.JwtEncoder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrationTest {
+
+    private val migration = Migration(serializer = Json)
+    private val jwtEncoder = JwtEncoder(serializer = Json)
+    private val idToken = Jwt(
+        header = Jwt.Header(
+            alg = "none",
+        ),
+        payload = Jwt.Payload(
+            iss = "issuer",
+            sub = "8582ce26-3994-42e7-afb0-39d42e18fd1f",
+            aud = listOf("clientId"),
+            exp = TEST_INSTANT + 600,
+            iat = TEST_INSTANT,
+        ),
+    )
+
+    @Test
+    fun `setTokens should set tokens on client`() = runTest {
+        val client = createTestClient()
+
+        migration.setTokens(
+            client = client,
+            accessToken = "eosvcZMZq7e",
+            accessTokenExpiresAt = TEST_INSTANT + 600,
+            refreshToken = "m3h8Gu2r",
+            refreshTokenExpiresAt = TEST_INSTANT + 1_209_600,
+            idToken = jwtEncoder.encode(idToken),
+        )
+
+        runCurrent()
+        val tokens = client.tokens.value
+
+        assertEquals("eosvcZMZq7e", tokens?.accessToken?.token)
+        assertEquals(TEST_INSTANT + 600, tokens?.accessToken?.expiresAt)
+        assertEquals("m3h8Gu2r", tokens?.refreshToken?.token)
+        assertEquals(TEST_INSTANT + 1_209_600, tokens?.refreshToken?.expiresAt)
+        assertEquals("issuer", tokens?.idToken?.issuer)
+        assertEquals("8582ce26-3994-42e7-afb0-39d42e18fd1f", tokens?.idToken?.subject)
+        assertEquals(TEST_INSTANT + 600, tokens?.idToken?.expiration)
+        assertEquals(TEST_INSTANT, tokens?.idToken?.issuedAt)
+        assertContains(tokens?.idToken?.audiences.orEmpty(), "clientId")
+    }
+
+    @Test
+    fun `setTokens should throw exception on migrated client`() = runTest {
+        val client = createTestClient {
+            copy(migrated = true)
+        }
+
+        assertFailsWith<IllegalStateException> {
+            migration.setTokens(
+                client = client,
+                accessToken = "eosvcZMZq7e",
+                accessTokenExpiresAt = TEST_INSTANT + 600,
+                refreshToken = "m3h8Gu2r",
+                refreshTokenExpiresAt = TEST_INSTANT + 1_209_600,
+                idToken = jwtEncoder.encode(idToken),
+            )
+        }
+    }
+
+    @Test
+    fun `isMigrated should return true after migration`() = runTest {
+        val client = createTestClient()
+
+        assertFalse(migration.isMigrated(client))
+
+        migration.setTokens(
+            client = client,
+            accessToken = "eosvcZMZq7e",
+            accessTokenExpiresAt = TEST_INSTANT + 600,
+            refreshToken = "m3h8Gu2r",
+            refreshTokenExpiresAt = TEST_INSTANT + 1_209_600,
+            idToken = jwtEncoder.encode(idToken),
+        )
+
+        runCurrent()
+
+        assertTrue(migration.isMigrated(client))
+    }
+
+    @Test
+    fun `setMigrated should set the migration flag`() = runTest {
+        val client = createTestClient()
+
+        assertFalse(migration.isMigrated(client))
+
+        migration.setMigrated(client)
+        runCurrent()
+
+        assertTrue(migration.isMigrated(client))
+    }
+}

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/end_session/EndSessionFlowTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/end_session/EndSessionFlowTest.kt
@@ -10,6 +10,7 @@ import dev.lokksmith.client.createTestClient
 import dev.lokksmith.client.request.OAuthError
 import dev.lokksmith.client.request.OAuthResponseException
 import dev.lokksmith.client.request.parameter.Parameter
+import dev.lokksmith.client.snapshot.Snapshot
 import dev.lokksmith.client.snapshot.Snapshot.EphemeralEndSessionFlowState
 import dev.lokksmith.client.snapshot.Snapshot.FlowResult
 import io.ktor.http.Url
@@ -31,13 +32,10 @@ class EndSessionFlowTest {
 
     @Test
     fun `prepare should prepare End Session Flow`() = runTest {
-        val (flow, client) = createFlow()
-
-        client.updateSnapshot {
+        val (flow, client) = createFlow {
             copy(tokens = SAMPLE_TOKENS)
         }
 
-        runCurrent()
         val initiation = flow.prepare()
 
         runCurrent()
@@ -64,13 +62,10 @@ class EndSessionFlowTest {
 
     @Test
     fun `onResponse should handle successful response`() = runTest {
-        val (flow, client) = createFlow()
-
-        client.updateSnapshot {
+        val (flow, client) = createFlow {
             copy(tokens = SAMPLE_TOKENS)
         }
 
-        runCurrent()
         assertNotNull(client.tokens.value)
 
         flow.prepare()
@@ -153,10 +148,12 @@ private suspend fun TestScope.createFlow(
     request: EndSessionFlow.Request = EndSessionFlow.Request(
         redirectUri = "https://example.com/app/redirect",
     ),
+    initialSnapshot: Snapshot.() -> Snapshot = { this },
 ): Pair<EndSessionFlow, InternalClient> {
     val client = createTestClient(
         key = key,
         id = id,
+        initialSnapshot = initialSnapshot,
     )
 
     return Pair(

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotMigrationTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotMigrationTest.kt
@@ -1,0 +1,62 @@
+package dev.lokksmith.client.snapshot
+
+import dev.lokksmith.client.createTestClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SnapshotMigrationTest {
+
+    @Test
+    fun `migrate should migrate client from schema version 1 to 2`() = runTest {
+        val snapshotStore = SnapshotStoreSpy(
+            SnapshotStoreImpl(
+                persistence = PersistenceFake(),
+                serializer = Json,
+            )
+        )
+
+        val client = createTestClient(
+            snapshotStore = snapshotStore,
+        ) {
+            copy(schemaVersion = 1)
+        }
+
+        snapshotStore.internalSetCalls.clear()
+
+        assertEquals(1, client.snapshots.value.schemaVersion)
+
+        client.migrate()
+        runCurrent()
+
+        assertEquals(2, client.snapshots.value.schemaVersion)
+        assertEquals(1, snapshotStore.internalSetCalls.size)
+    }
+
+    @Test
+    fun `migrate should not migrate current schema`() = runTest {
+        val snapshotStore = SnapshotStoreSpy(
+            SnapshotStoreImpl(
+                persistence = PersistenceFake(),
+                serializer = Json,
+            )
+        )
+
+        val client = createTestClient(
+            snapshotStore = snapshotStore,
+        )
+
+        snapshotStore.internalSetCalls.clear()
+
+        assertEquals(CURRENT_SCHEMA_VERSION, client.snapshots.value.schemaVersion)
+
+        client.migrate()
+        runCurrent()
+
+        assertEquals(0, snapshotStore.internalSetCalls.size)
+    }
+}

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotStoreSpy.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotStoreSpy.kt
@@ -10,12 +10,14 @@ internal class SnapshotStoreSpy(
     data class ObserveCall(val key: Key)
     data class GetForStateCall(val state: String)
     data class SetCall(val key: Key, val snapshot: Snapshot)
+    data class InternalSetCall(val key: Key, val snapshot: Snapshot)
     data class DeleteCall(val key: Key)
     data class ExistsCall(val key: Key)
 
     val observeCalls = mutableListOf<ObserveCall>()
     val getForStateCalls = mutableListOf<GetForStateCall>()
     val setCalls = mutableListOf<SetCall>()
+    val internalSetCalls = mutableListOf<InternalSetCall>()
     val deleteCalls = mutableListOf<DeleteCall>()
     val existsCalls = mutableListOf<ExistsCall>()
 
@@ -35,6 +37,14 @@ internal class SnapshotStoreSpy(
     ): Snapshot {
         setCalls.add(SetCall(key, snapshot))
         return subject.set(key, snapshot)
+    }
+
+    override suspend fun internalSet(
+        key: Key,
+        snapshot: Snapshot
+    ): Snapshot {
+        internalSetCalls.add(InternalSetCall(key, snapshot))
+        return subject.internalSet(key, snapshot)
     }
 
     override suspend fun delete(key: Key): Boolean {


### PR DESCRIPTION
A flag has been added to the client snapshot which allows identifying already migrated clients.