### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,7 @@
 name: Check Pull Request
 on: [ pull_request, workflow_dispatch ]
+permissions:
+  contents: read
 jobs:
   check-lib:
     timeout-minutes: 30

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: Check Pull Request
-on: [ pull_request, workflow_dispatch ]
 permissions:
   contents: read
+on: [ pull_request, workflow_dispatch ]
 jobs:
   check-lib:
     timeout-minutes: 30


### PR DESCRIPTION
Potential fix for [https://github.com/svenjacobs/lokksmith/security/code-scanning/3](https://github.com/svenjacobs/lokksmith/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will apply to all jobs in the workflow unless overridden at the job level. Based on the workflow's steps, it appears that the jobs only need to read the repository contents and do not require any write permissions. Therefore, we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
