### PR TITLE
feat: add state property to Initiation and result classes

### DIFF
--- a/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/AppViewModel.kt
+++ b/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/AppViewModel.kt
@@ -88,9 +88,9 @@ class AppViewModel(
                 .filterNotNull()
                 .collect { result ->
                     when (result) {
-                        Result.Processing -> isLoading.value = true
+                        is Result.Processing -> isLoading.value = true
 
-                        Result.Cancelled -> {
+                        is Result.Cancelled -> {
                             isLoading.value = false
                             error.value = "Flow was cancelled"
                         }
@@ -100,7 +100,7 @@ class AppViewModel(
                             error.value = result.message
                         }
 
-                        Result.Success -> isLoading.value = false
+                        is Result.Success -> isLoading.value = false
 
                         Result.Undefined -> isLoading.value = false
                     }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -521,13 +521,15 @@ internal class ClientImpl private constructor(
     }
 
     override suspend fun cancelPendingFlow() {
-        val cancellation = when (snapshots.value.ephemeralFlowState) {
+        val ephemeralFlowState =
+            checkNotNull(snapshots.value.ephemeralFlowState) { "ephemeral flow state is null" }
+
+        val cancellation = when (ephemeralFlowState) {
             is Snapshot.EphemeralAuthorizationCodeFlowState -> ::AuthorizationCodeFlowCancellation
             is Snapshot.EphemeralEndSessionFlowState -> ::EndSessionFlowCancellation
-            null -> throw IllegalStateException("ephemeral flow state is null")
         }(this)
 
-        cancellation.cancel()
+        cancellation.cancel(ephemeralFlowState.state)
     }
 
     override fun dispose() {

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlow.kt
@@ -6,6 +6,7 @@ import dev.lokksmith.client.snapshot.Snapshot
 
 public abstract class AbstractAuthFlow internal constructor(
     internal val client: InternalClient,
+    internal val state: String,
     private val responseHandler: AuthFlowResponseHandler,
     private val cancellation: AuthFlowCancellation,
 ) : AuthFlow {
@@ -30,6 +31,7 @@ public abstract class AbstractAuthFlow internal constructor(
         }
 
         return Initiation(
+            state = state,
             requestUrl = onPrepare(),
             clientKey = client.key.value,
         )
@@ -40,6 +42,6 @@ public abstract class AbstractAuthFlow internal constructor(
     }
 
     override suspend fun cancel() {
-        cancellation.cancel()
+        cancellation.cancel(state)
     }
 }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlowCancellation.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlowCancellation.kt
@@ -11,10 +11,10 @@ public abstract class AbstractAuthFlowCancellation(
 
     internal open fun Snapshot.onUpdateSnapshot(): Snapshot = this
 
-    override suspend fun cancel() {
+    override suspend fun cancel(state: String) {
         stateFinalizer.finalize {
             copy(
-                flowResult = FlowResult.Cancelled,
+                flowResult = FlowResult.Cancelled(state = state),
             ).onUpdateSnapshot()
         }
     }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlowResponseHandler.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AbstractAuthFlowResponseHandler.kt
@@ -15,7 +15,7 @@ import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
 
 public abstract class AbstractAuthFlowResponseHandler(
-    state: String,
+    private val state: String,
     protected val client: InternalClient,
     private val stateFinalizer: AuthFlowStateFinalizer = AuthFlowStateFinalizer(client),
 ) : AuthFlowResponseHandler {
@@ -46,12 +46,13 @@ public abstract class AbstractAuthFlowResponseHandler(
 
             requireResponseSuccess(url)
             onResponse(url)
-            setResult(FlowResult.Success)
+            setResult(FlowResult.Success(state))
         } catch (e: CancellationException) {
             throw e
         } catch (e: OAuthResponseException) {
             setResult(
                 FlowResult.Error(
+                    state = state,
                     type = Type.OAuth,
                     message = e.message,
                     code = e.error.code,
@@ -62,6 +63,7 @@ public abstract class AbstractAuthFlowResponseHandler(
         } catch (e: TokenTemporalValidationException) {
             setResult(
                 FlowResult.Error(
+                    state = state,
                     type = Type.TemporalValidation,
                     message = e.message,
                 )
@@ -71,6 +73,7 @@ public abstract class AbstractAuthFlowResponseHandler(
         } catch (e: TokenValidationException) {
             setResult(
                 FlowResult.Error(
+                    state = state,
                     type = Type.Validation,
                     message = e.message,
                 )
@@ -80,6 +83,7 @@ public abstract class AbstractAuthFlowResponseHandler(
         } catch (e: Exception) {
             setResult(
                 FlowResult.Error(
+                    state = state,
                     type = Type.Generic,
                     message = e.message,
                 )

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlow.kt
@@ -52,10 +52,15 @@ public interface AuthFlow {
      *
      * This class is designed to be easily serializable and should only contain basic data types,
      * making it suitable for use with UI frameworks, serialization and inter-process communication.
+     *
+     * @param state State parameter of this auth flow
+     * @param requestUrl Request URL to be called
+     * @param clientKey Key of initiating client
      */
     @Immutable
     @Poko
     public class Initiation(
+        public val state: String,
         public val requestUrl: String,
         public val clientKey: String,
     )

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlowCancellation.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlowCancellation.kt
@@ -5,5 +5,5 @@ package dev.lokksmith.client.request.flow
  */
 public interface AuthFlowCancellation {
 
-    public suspend fun cancel()
+    public suspend fun cancel(state: String)
 }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlowResultProvider.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/AuthFlowResultProvider.kt
@@ -25,14 +25,24 @@ public object AuthFlowResultProvider {
 
         public data object Undefined : Result
 
-        public data object Processing : Result
+        @Poko
+        public class Processing(
+            public val state: String,
+        ) : Result
 
-        public data object Success : Result
+        @Poko
+        public class Success(
+            public val state: String,
+        ) : Result
 
-        public data object Cancelled : Result
+        @Poko
+        public class Cancelled(
+            public val state: String,
+        ) : Result
 
         @Poko
         public class Error(
+            public val state: String,
             public val type: Type,
             public val message: String?,
             public val code: String? = null,
@@ -54,9 +64,10 @@ public object AuthFlowResultProvider {
             .map { snapshot ->
                 val flowResult = snapshot.flowResult
                 when {
-                    flowResult == Snapshot.FlowResult.Success -> Result.Success
-                    flowResult == Snapshot.FlowResult.Cancelled -> Result.Cancelled
+                    flowResult is Snapshot.FlowResult.Success -> Result.Success(state = flowResult.state)
+                    flowResult is Snapshot.FlowResult.Cancelled -> Result.Cancelled(state = flowResult.state)
                     flowResult is Snapshot.FlowResult.Error -> Result.Error(
+                        state = flowResult.state,
                         type = when (flowResult.type) {
                             FlowResultErrorType.Generic -> Type.Generic
                             FlowResultErrorType.OAuth -> Type.OAuth
@@ -67,7 +78,10 @@ public object AuthFlowResultProvider {
                         code = flowResult.code,
                     )
 
-                    snapshot.ephemeralFlowState != null -> Result.Processing
+                    snapshot.ephemeralFlowState != null -> Result.Processing(
+                        state = snapshot.ephemeralFlowState.state,
+                    )
+
                     else -> Result.Undefined
                 }
             }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlow.kt
@@ -29,13 +29,14 @@ import kotlinx.serialization.json.Json
  */
 public class AuthorizationCodeFlow private constructor(
     client: InternalClient,
+    state: String,
     responseHandler: AuthorizationCodeFlowResponseHandler,
     private val request: Request,
-    internal val state: String,
     internal val nonce: String?,
     internal val codeVerifier: String?,
 ) : AbstractAuthFlow(
     client = client,
+    state = state,
     responseHandler = responseHandler,
     cancellation = AuthorizationCodeFlowCancellation(client),
 ) {
@@ -189,9 +190,9 @@ public class AuthorizationCodeFlow private constructor(
 
             return AuthorizationCodeFlow(
                 client = client,
+                state = state,
                 responseHandler = responseHandler,
                 request = request,
-                state = state,
                 nonce = nonce,
                 codeVerifier = codeVerifier,
             )

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlow.kt
@@ -19,11 +19,12 @@ import io.ktor.http.takeFrom
  */
 public class EndSessionFlow internal constructor(
     client: InternalClient,
+    state: String,
     private val request: Request,
-    internal val state: String,
     private val endpoint: String,
 ) : AbstractAuthFlow(
     client = client,
+    state = state,
     responseHandler = EndSessionFlowResponseHandler(state, client),
     cancellation = EndSessionFlowCancellation(client),
 ) {
@@ -89,8 +90,8 @@ public class EndSessionFlow internal constructor(
 
             EndSessionFlow(
                 client = client,
-                request = request,
                 state = state,
+                request = request,
                 endpoint = it,
             )
         }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
@@ -53,15 +53,22 @@ public data class Snapshot(
     @Serializable
     public sealed interface FlowResult {
 
+        @Poko
         @Serializable
-        public data object Success : FlowResult
+        public class Success(
+            public val state: String,
+        ) : FlowResult
 
+        @Poko
         @Serializable
-        public data object Cancelled : FlowResult
+        public class Cancelled(
+            public val state: String,
+        ) : FlowResult
 
         @Poko
         @Serializable
         public class Error(
+            public val state: String,
             @SerialName("errorType")
             public val type: Type,
             public val message: String?,

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -186,14 +186,14 @@ class ClientTest {
                 copy(
                     tokens = SAMPLE_TOKENS,
                     nonce = "0D1ck61",
-                    flowResult = FlowResult.Success,
+                    flowResult = FlowResult.Success(state = "f3SSmdwW"),
                 )
             }
         )
 
         assertEquals(SAMPLE_TOKENS, client.snapshots.value.tokens)
         assertEquals("0D1ck61", client.snapshots.value.nonce)
-        assertEquals(FlowResult.Success, client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Success(state = "f3SSmdwW"), client.snapshots.value.flowResult)
 
         client.resetTokens()
         runCurrent()

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTest.kt
@@ -223,7 +223,7 @@ class AuthorizationCodeFlowTest {
         assertEquals(tokens.idToken.issuedAt, TEST_INSTANT)
         assertEquals(tokens.idToken.nonce, flow.nonce)
 
-        assertEquals(FlowResult.Success, client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Success(state = flow.state), client.snapshots.value.flowResult)
     }
 
     @Test
@@ -253,6 +253,7 @@ class AuthorizationCodeFlowTest {
 
         assertEquals(
             FlowResult.Error(
+                state = flow.state,
                 type = FlowResult.Error.Type.OAuth,
                 message = """OAuthResponseException(error="invalid_grant, errorDescription="error description", errorUri="error URI")""",
                 code = OAuthError.InvalidGrant.code,
@@ -303,6 +304,7 @@ class AuthorizationCodeFlowTest {
 
         assertEquals(
             FlowResult.Error(
+                state = flow.state,
                 type = FlowResult.Error.Type.OAuth,
                 message = """OAuthResponseException(error="invalid_grant, errorDescription="error description", errorUri="error URI", statusCode=400)""",
                 code = OAuthError.InvalidGrant.code,
@@ -345,7 +347,7 @@ class AuthorizationCodeFlowTest {
 
         assertNull(client.snapshots.value.ephemeralFlowState)
         assertNull(client.snapshots.value.nonce)
-        assertEquals(FlowResult.Cancelled, client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Cancelled(state = flow.state), client.snapshots.value.flowResult)
     }
 }
 

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlowTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlowTest.kt
@@ -79,7 +79,7 @@ class EndSessionFlowTest {
         flow.onResponse(responseUrl)
         runCurrent()
 
-        assertEquals(FlowResult.Success, client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Success(state = flow.state), client.snapshots.value.flowResult)
         assertNull(client.tokens.value)
     }
 
@@ -110,6 +110,7 @@ class EndSessionFlowTest {
 
         assertEquals(
             FlowResult.Error(
+                state = flow.state,
                 type = FlowResult.Error.Type.OAuth,
                 message = """OAuthResponseException(error="invalid_client, errorDescription="error description", errorUri="error URI")""",
                 code = OAuthError.InvalidClient.code,
@@ -139,7 +140,7 @@ class EndSessionFlowTest {
         runCurrent()
 
         assertNull(client.snapshots.value.ephemeralFlowState)
-        assertEquals(FlowResult.Cancelled, client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Cancelled(state = flow.state), client.snapshots.value.flowResult)
     }
 }
 


### PR DESCRIPTION
The `state` property in `Initiation` allows to match it with the `Result` classes.
This enables a developer to be absolutely certain about the responses belonging to a specific initiated flow.