### PR TITLE
chore: move Client.Options to creating lambda

### DIFF
--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/CreateContext.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/CreateContext.kt
@@ -6,6 +6,7 @@ import dev.lokksmith.client.Client
  * Context for creating a new [Client].
  *
  * [id] must be specified as well as one of [discoveryUrl] or [metadata].
+ * [options] can be used to tweak the behaviour of the client.
  *
  * @see Lokksmith.create
  * @see Lokksmith.getOrCreate
@@ -17,6 +18,7 @@ public class CreateContext internal constructor(
         var id: String? = null,
         var metadata: Client.Metadata? = null,
         var discoveryUrl: String? = null,
+        var options: Client.Options = Client.Options(),
     )
 
     internal fun validate() {
@@ -28,19 +30,28 @@ public class CreateContext internal constructor(
 }
 
 public var CreateContext.id: String
-    get() = throw UnsupportedOperationException()
+    get() = throw UnsupportedOperationException("id cannot be read")
     set(value) {
         props.id = value
     }
 
 public var CreateContext.discoveryUrl: String
-    get() = throw UnsupportedOperationException()
+    get() = throw UnsupportedOperationException("discoveryUrl cannot be read")
     set(value) {
         props.discoveryUrl = value
     }
 
 public var CreateContext.metadata: Client.Metadata
-    get() = throw UnsupportedOperationException()
+    get() = throw UnsupportedOperationException("metadata cannot be read")
     set(value) {
         props.metadata = value
+    }
+
+/**
+ * Options for configuring the behaviour of the client.
+ */
+public var CreateContext.options: Client.Options
+    get() = throw UnsupportedOperationException("options cannot be read")
+    set(value) {
+        props.options = value
     }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/Lokksmith.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/Lokksmith.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.cancel
  * and utilize that **singleton** reference for getting or creating [Client] instances. If you
  * absolutely must use multiple instances, make sure that each one uses a unique persistence file
  * specified via [Options.persistenceFileBaseName]. Any other configuration may lead to undefined or
- * erroneous behavior.
+ * erroneous behaviour.
  *
  * Use the platform-specific `createLokksmith()` function to create an instance.
  *
@@ -121,19 +121,18 @@ public class Lokksmith internal constructor(
      * Calling [getOrCreate] multiple times with the same key returns new [Client] instances that
      * share synchronized state. However, it's recommended to use a single instance per unique key.
      *
-     * The passed [options] are only applied to newly created clients. For adjusting the
-     * configuration of an existing client see [Client.options].
+     * The passed [CreateContext.options] in the provided [builder] lambda are only applied to newly
+     * created clients. For adjusting the configuration of an existing client see [Client.options].
      *
      * @param key Key of new client
-     * @param options Options for configuring the behavior of the client **if** the client was newly
+     * @param options Options for configuring the behaviour of the client **if** the client was newly
      *                created
      */
     public suspend fun getOrCreate(
         key: String,
-        options: Client.Options = Client.Options(),
         builder: CreateContext.() -> Unit,
     ): Client =
-        get(key) ?: create(key, options, builder)
+        get(key) ?: create(key, builder)
 
     /**
      * Returns `true` if a client for the given [key] exists.
@@ -146,11 +145,9 @@ public class Lokksmith internal constructor(
      * [builder] for initial configuration.
      *
      * @param key Key of new client
-     * @param options Options for configuring the behavior of the client
      */
     public suspend fun create(
         key: String,
-        options: Client.Options = Client.Options(),
         builder: CreateContext.() -> Unit,
     ): Client {
         require(!exists(key)) { "client with key \"$key\" already exists" }
@@ -173,7 +170,7 @@ public class Lokksmith internal constructor(
                 key = key,
                 id = id,
                 metadata = metadata,
-                options = options,
+                options = context.props.options,
             )
         )
 
@@ -189,7 +186,7 @@ public class Lokksmith internal constructor(
      * Deletes client with the given [key] or returns `false` if client doesn't exist.
      *
      * Don't use a [Client] instance for given key after it has been deleted. Doing so might result
-     * in undefined and erroneous behavior.
+     * in undefined and erroneous behaviour.
      */
     public suspend fun delete(key: String): Boolean =
         container.snapshotStore.delete(key.asKey())
@@ -199,7 +196,7 @@ public class Lokksmith internal constructor(
      *
      * After calling this method, the Lokksmith instance and all [Clients][Client] produced by it
      * become nonfunctional and must not be used. Any ongoing operations may be cancelled, and
-     * further method calls may result in undefined behavior.
+     * further method calls may result in undefined behaviour.
      *
      * This method should be called when the Lokksmith instance is no longer needed to avoid
      * resource leaks.

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -72,7 +72,7 @@ public interface Client {
     )
 
     /**
-     * Options to configure the behavior of this client.
+     * Options to configure the behaviour of this client.
      */
     @Serializable
     public data class Options(
@@ -204,7 +204,7 @@ public interface Client {
     public var metadata: Metadata
 
     /**
-     * Options for configuring the behavior of this client.
+     * Options for configuring the behaviour of this client.
      *
      * @see Options
      * @see [Lokksmith.getOrCreate]
@@ -315,7 +315,7 @@ public interface Client {
      *
      * After calling this method, the client instance becomes nonfunctional and must not be used.
      * Any ongoing operations may be cancelled, and further method calls may result in undefined
-     * behavior.
+     * behaviour.
      *
      * This method should be called when the client is no longer needed to avoid resource leaks.
      *

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/LokksmithTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/LokksmithTest.kt
@@ -91,9 +91,11 @@ class LokksmithTest {
         val client = lokksmith.getOrCreate(key.value) {
             id = "clientId"
             discoveryUrl = "https://example.com/.well-known/openid-configuration"
+            options = Client.Options(leewaySeconds = 30)
         }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)
+        assertEquals(Client.Options(), client.options)
 
         assertEquals(1, snapshotStore.existsCalls.size)
         assertContains(
@@ -118,9 +120,11 @@ class LokksmithTest {
         val client = lokksmith.getOrCreate(key.value) {
             id = "clientId"
             discoveryUrl = "https://example.com/.well-known/openid-configuration"
+            options = Client.Options(leewaySeconds = 30)
         }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)
+        assertEquals(Client.Options(leewaySeconds = 30), client.options)
 
         assertEquals(2, snapshotStore.existsCalls.size)
         assertEquals(
@@ -137,7 +141,7 @@ class LokksmithTest {
                     key = key,
                     id = "clientId".asId(),
                     metadata = mockMetadata,
-                    options = Client.Options(),
+                    options = Client.Options(leewaySeconds = 30),
                 )
             ),
             "SnapshotStore.set() not called",
@@ -195,15 +199,13 @@ class LokksmithTest {
         val (lokksmith, snapshotStore) = createTestLokksmith()
 
         val key = "key".asKey()
-        val client = lokksmith.create(
-            key = key.value,
+        val client = lokksmith.create(key.value) {
+            id = "clientId"
+            discoveryUrl = "https://example.com/.well-known/openid-configuration"
             options = Client.Options(
                 leewaySeconds = 5,
                 preemptiveRefreshSeconds = 30,
-            ),
-        ) {
-            id = "clientId"
-            discoveryUrl = "https://example.com/.well-known/openid-configuration"
+            )
         }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)


### PR DESCRIPTION
Makes it clear that `Options` are only applied when creating a client.