### PR TITLE
chore(deps): remove obsolete, explicit dependencies

### DIFF
--- a/lib/gradle/libs.versions.toml
+++ b/lib/gradle/libs.versions.toml
@@ -16,8 +16,6 @@ androidx-activity = { module = "androidx.activity:activity", version.ref = "andr
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androix-activity" }
 androidx-browser = "androidx.browser:browser:1.8.0"
 androidx-compose-bom = "androidx.compose:compose-bom:2025.06.01"
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
-androidx-compose-runtime-saveable = { module = "androidx.compose.runtime:runtime-saveable" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core", version.ref = "cryptography" }

--- a/lib/lokksmith-android/build.gradle.kts
+++ b/lib/lokksmith-android/build.gradle.kts
@@ -51,8 +51,6 @@ dependencies {
     api(project(":lokksmith-core"))
     api(libs.androidx.activity.compose)
     api(libs.androidx.browser)
-    api(libs.androidx.compose.runtime)
-    api(libs.androidx.compose.runtime.saveable)
     api(libs.androidx.compose.ui)
 }
 


### PR DESCRIPTION
Their are implicit dependencies of `androidx.compose.ui`.