### PR TITLE
feat: improve flow result confirmation

### DIFF
--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -473,9 +473,7 @@ private constructor(
     override suspend fun resetTokens(): Boolean {
         if (snapshots.value.tokens == null) return false
 
-        updateSnapshot {
-            copy(tokens = null, nonce = null, flowResult = null, ephemeralFlowState = null)
-        }
+        updateSnapshot { copy(tokens = null, nonce = null, ephemeralFlowState = null) }
 
         return true
     }
@@ -509,8 +507,10 @@ private constructor(
                 when (val state = ephemeralFlowState) {
                     is Snapshot.EphemeralAuthorizationCodeFlowState ->
                         state.copy(responseUri = responseUri)
+
                     is Snapshot.EphemeralEndSessionFlowState ->
                         state.copy(responseUri = responseUri)
+
                     null -> throw IllegalStateException("ephemeralFlowState is null")
                 }
 
@@ -526,6 +526,7 @@ private constructor(
             when (ephemeralFlowState) {
                 is Snapshot.EphemeralAuthorizationCodeFlowState ->
                     ::AuthorizationCodeFlowCancellation
+
                 is Snapshot.EphemeralEndSessionFlowState -> ::EndSessionFlowCancellation
             }(this)
 

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
@@ -82,6 +82,8 @@ public data class Snapshot(
                 TemporalValidation,
             }
         }
+
+        @Serializable public data object Consumed : FlowResult
     }
 
     @Serializable

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -207,7 +207,7 @@ class ClientTest {
 
         assertNull(client.snapshots.value.tokens)
         assertNull(client.snapshots.value.nonce)
-        assertNull(client.snapshots.value.flowResult)
+        assertEquals(FlowResult.Success(state = "f3SSmdwW"), client.snapshots.value.flowResult)
     }
 
     @Test


### PR DESCRIPTION
Previously we might have received some intermediate `Undefined` result states which is not desired.