### PR TITLE
chore: enable minification for demo release build

### DIFF
--- a/demo/composeApp/build.gradle.kts
+++ b/demo/composeApp/build.gradle.kts
@@ -77,7 +77,8 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {


### PR DESCRIPTION
The supplied R8 rules by KotlinX Serialization ensure that minification doesn't break the app.