### PR TITLE
chore: remove Client.Options from persistence

### DIFF
--- a/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/AppViewModel.kt
+++ b/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/AppViewModel.kt
@@ -130,7 +130,10 @@ class AppViewModel(
         url: String,
     ) {
         viewModelScope.launch(exceptionHandler) {
-            val client = lokksmith.getOrCreate(clientId) {
+            val client = lokksmith.getOrCreate(
+                key = clientId,
+                options = Client.Options(leewaySeconds = 30),
+            ) {
                 id = clientId
                 discoveryUrl = url
             }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/CreateContext.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/CreateContext.kt
@@ -20,8 +20,7 @@ import dev.lokksmith.client.Client
 /**
  * Context for creating a new [Client].
  *
- * [id] must be specified as well as one of [discoveryUrl] or [metadata]. [options] can be used to
- * tweak the behaviour of the client.
+ * [id] must be specified as well as one of [discoveryUrl] or [metadata].
  *
  * @see Lokksmith.create
  * @see Lokksmith.getOrCreate
@@ -31,7 +30,6 @@ public class CreateContext internal constructor(internal val props: Properties =
         var id: String? = null,
         var metadata: Client.Metadata? = null,
         var discoveryUrl: String? = null,
-        var options: Client.Options = Client.Options(),
     )
 
     internal fun validate() {
@@ -58,11 +56,4 @@ public var CreateContext.metadata: Client.Metadata
     get() = throw UnsupportedOperationException("metadata cannot be read")
     set(value) {
         props.metadata = value
-    }
-
-/** Options for configuring the behaviour of the client. */
-public var CreateContext.options: Client.Options
-    get() = throw UnsupportedOperationException("options cannot be read")
-    set(value) {
-        props.options = value
     }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -86,7 +86,6 @@ public interface Client {
     )
 
     /** Options to configure the behaviour of this client. */
-    @Serializable
     public data class Options(
         /**
          * The number of seconds of clock skew to allow when validating time-based claims in tokens,
@@ -380,6 +379,7 @@ public interface InternalClient : Client {
 internal class ClientImpl
 private constructor(
     override val key: Key,
+    override var options: Client.Options,
     override val tokens: StateFlow<Tokens?>,
     override val provider: Provider,
     private val snapshotContract: SnapshotContract,
@@ -423,12 +423,6 @@ private constructor(
         get() = snapshots.value.metadata
         set(value) {
             coroutineScope.launch { updateSnapshot { copy(metadata = value) } }
-        }
-
-    override var options: Client.Options
-        get() = snapshots.value.options
-        set(value) {
-            coroutineScope.launch { updateSnapshot { copy(options = value) } }
         }
 
     override suspend fun refresh(): Tokens {
@@ -547,6 +541,7 @@ private constructor(
          */
         internal suspend fun create(
             key: Key,
+            options: Client.Options,
             coroutineScope: CoroutineScope,
             snapshotStore: SnapshotStore,
             provider: Provider,
@@ -569,6 +564,7 @@ private constructor(
 
             return ClientImpl(
                 key = key,
+                options = options,
                 tokens = tokens,
                 provider = provider,
                 snapshotContract = snapshotContract,

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/Snapshot.kt
@@ -19,19 +19,22 @@ import dev.drewhamilton.poko.Poko
 import dev.lokksmith.client.Client
 import dev.lokksmith.client.Id
 import dev.lokksmith.client.Key
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 
 internal const val CURRENT_SCHEMA_VERSION = 2
 
 /** A [Snapshot] represents the persistable state of a [Client]. */
 @Serializable
+@JsonIgnoreUnknownKeys
+@OptIn(ExperimentalSerializationApi::class)
 public data class Snapshot(
     val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
     val key: Key,
     val id: Id,
     val metadata: Client.Metadata,
-    val options: Client.Options,
     val tokens: Client.Tokens? = null,
 
     /**

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/LokksmithTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/LokksmithTest.kt
@@ -59,13 +59,7 @@ class LokksmithTest {
         val key = "key".asKey()
         snapshotStore.set(
             key = key,
-            snapshot =
-                Snapshot(
-                    key = key,
-                    id = "clientId".asId(),
-                    metadata = mockMetadata,
-                    options = Client.Options(),
-                ),
+            snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
         )
 
         val client = assertNotNull(lokksmith.get(key.value))
@@ -95,25 +89,18 @@ class LokksmithTest {
         val key = "key".asKey()
         snapshotStore.set(
             key = key,
-            snapshot =
-                Snapshot(
-                    key = key,
-                    id = "clientId".asId(),
-                    metadata = mockMetadata,
-                    options = Client.Options(),
-                ),
+            snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
         )
         snapshotStore.setCalls.clear()
 
         val client =
-            lokksmith.getOrCreate(key.value) {
+            lokksmith.getOrCreate(key = key.value, options = Client.Options(leewaySeconds = 30)) {
                 id = "clientId"
                 discoveryUrl = "https://example.com/.well-known/openid-configuration"
-                options = Client.Options(leewaySeconds = 30)
             }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)
-        assertEquals(Client.Options(), client.options)
+        assertEquals(Client.Options(leewaySeconds = 30), client.options)
 
         assertEquals(1, snapshotStore.existsCalls.size)
         assertContains(
@@ -136,10 +123,9 @@ class LokksmithTest {
 
         val key = "key".asKey()
         val client =
-            lokksmith.getOrCreate(key.value) {
+            lokksmith.getOrCreate(key = key.value, options = Client.Options(leewaySeconds = 30)) {
                 id = "clientId"
                 discoveryUrl = "https://example.com/.well-known/openid-configuration"
-                options = Client.Options(leewaySeconds = 30)
             }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)
@@ -156,13 +142,7 @@ class LokksmithTest {
             snapshotStore.setCalls,
             SetCall(
                 key = key,
-                snapshot =
-                    Snapshot(
-                        key = key,
-                        id = "clientId".asId(),
-                        metadata = mockMetadata,
-                        options = Client.Options(leewaySeconds = 30),
-                    ),
+                snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
             ),
             "SnapshotStore.set() not called",
         )
@@ -181,13 +161,7 @@ class LokksmithTest {
         val key = "key".asKey()
         snapshotStore.set(
             key = key,
-            snapshot =
-                Snapshot(
-                    key = key,
-                    id = "clientId".asId(),
-                    metadata = mockMetadata,
-                    options = Client.Options(),
-                ),
+            snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
         )
 
         assertTrue(lokksmith.exists(key.value))
@@ -221,10 +195,12 @@ class LokksmithTest {
 
         val key = "key".asKey()
         val client =
-            lokksmith.create(key.value) {
+            lokksmith.create(
+                key = key.value,
+                options = Client.Options(leewaySeconds = 5, preemptiveRefreshSeconds = 30),
+            ) {
                 id = "clientId"
                 discoveryUrl = "https://example.com/.well-known/openid-configuration"
-                options = Client.Options(leewaySeconds = 5, preemptiveRefreshSeconds = 30)
             }
         assertEquals("clientId".asId(), client.id)
         assertEquals(mockMetadata, client.metadata)
@@ -240,13 +216,7 @@ class LokksmithTest {
             snapshotStore.setCalls,
             SetCall(
                 key = key,
-                snapshot =
-                    Snapshot(
-                        key = key,
-                        id = "clientId".asId(),
-                        metadata = mockMetadata,
-                        options = Client.Options(leewaySeconds = 5, preemptiveRefreshSeconds = 30),
-                    ),
+                snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
             ),
             "SnapshotStore.set() not called",
         )
@@ -265,13 +235,7 @@ class LokksmithTest {
         val key = "key".asKey()
         snapshotStore.set(
             key = key,
-            snapshot =
-                Snapshot(
-                    key = key,
-                    id = "clientId".asId(),
-                    metadata = mockMetadata,
-                    options = Client.Options(),
-                ),
+            snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
         )
 
         assertFailsWith<IllegalArgumentException> {
@@ -295,13 +259,7 @@ class LokksmithTest {
         val key = "key".asKey()
         snapshotStore.set(
             key = key,
-            snapshot =
-                Snapshot(
-                    key = key,
-                    id = "clientId".asId(),
-                    metadata = mockMetadata,
-                    options = Client.Options(),
-                ),
+            snapshot = Snapshot(key = key, id = "clientId".asId(), metadata = mockMetadata),
         )
 
         assertTrue(lokksmith.delete(key.value))

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -353,17 +353,17 @@ suspend fun TestScope.createTestClient(
                         tokenEndpoint = "https://example.com/tokenEndpoint",
                         endSessionEndpoint = "https://example.com/endSessionEndpoint",
                     ),
-                options = Client.Options(),
             ),
     )
 
     val client =
         ClientImpl.create(
             key = key,
+            options = Client.Options(),
             coroutineScope = backgroundScope,
             snapshotStore = snapshotStore,
             provider = provider,
-        ) as InternalClient
+        )
 
     client.updateSnapshot(initialSnapshot)
     runCurrent()

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotStoreTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/snapshot/SnapshotStoreTest.kt
@@ -162,7 +162,6 @@ private fun newSnapshot(key: Key, state: String? = null): Snapshot {
                 authorizationEndpoint = "authorizationEndpoint",
                 tokenEndpoint = "tokenEndpoint",
             ),
-        options = Client.Options(),
         ephemeralFlowState = ephemeralFlowState,
     )
 }


### PR DESCRIPTION
There was actually no reason why `Client.Options` should be persisted in the client state.