### PR TITLE
chore: remove kotlinx-datetime dependency

### DIFF
--- a/lib/gradle/libs.versions.toml
+++ b/lib/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-collections-immutable = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0"
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.7.0"
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serializaton" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serializaton" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/lib/lokksmith-core/build.gradle.kts
+++ b/lib/lokksmith-core/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
 
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.cryptography.core)
-            implementation(libs.kotlinx.datetime)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
 


### PR DESCRIPTION
It is actually not required anymore because `Clock` and `Instant` are available in stdlib since Kotlin 2.1.