### PR TITLE
feat: add Android callback for customizing Intent

### DIFF
--- a/demo/composeApp/src/androidMain/kotlin/dev/lokksmith/demo/MainActivity.kt
+++ b/demo/composeApp/src/androidMain/kotlin/dev/lokksmith/demo/MainActivity.kt
@@ -1,6 +1,7 @@
 package dev.lokksmith.demo
 
 import android.content.ClipData
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -21,6 +22,14 @@ class MainActivity : ComponentActivity() {
             val clipboard = LocalClipboard.current
 
             App(
+                onIntentCreated = { intent ->
+                    /**
+                     * Example of how we can force the authentication to be run in a specific
+                     * browser even when another browser is set as standard. Note, this will crash
+                     * the app if Chrome is not installed.
+                     */
+                    (intent as Intent).`package` = "com.android.chrome"
+                },
                 onCopyToClipboard = {
                     scope.launch {
                         clipboard.setClipEntry(

--- a/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/App.kt
+++ b/demo/composeApp/src/commonMain/kotlin/dev/lokksmith/demo/App.kt
@@ -78,6 +78,7 @@ import kotlin.time.Instant
 @OptIn(ExperimentalMaterial3Api::class)
 fun App(
     viewModel: AppViewModel = viewModel { AppViewModel() },
+    onIntentCreated: (Any) -> Unit = {},
     onCopyToClipboard: (String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -99,6 +100,7 @@ fun App(
                 initiation = it.initiation,
                 options = PlatformOptions(
                     android = PlatformOptions.Android(
+                        onIntentCreated = onIntentCreated,
                         method = PlatformOptions.Android.Method.AuthTab(),
                     ),
                 )

--- a/lib/lokksmith-compose/src/androidMain/kotlin/dev/lokksmith/compose/AuthFlowLauncher.android.kt
+++ b/lib/lokksmith-compose/src/androidMain/kotlin/dev/lokksmith/compose/AuthFlowLauncher.android.kt
@@ -140,6 +140,7 @@ private class AndroidPlatformLauncher(
                             ephemeralBrowsing = options.android.ephemeralBrowsing,
                         )
 
+                    options.android.onIntentCreated(intent)
                     activityLauncher.launch(intent)
                 }
 
@@ -148,6 +149,8 @@ private class AndroidPlatformLauncher(
                         AuthTabIntent.Builder()
                             .setEphemeralBrowsingEnabled(options.android.ephemeralBrowsing)
                             .build()
+
+                    options.android.onIntentCreated(authTabIntent.intent)
                     val url = initiation.requestUrl.toUri()
 
                     when (method.redirect) {

--- a/lib/lokksmith-compose/src/commonMain/kotlin/dev/lokksmith/compose/AuthFlowLauncher.kt
+++ b/lib/lokksmith-compose/src/commonMain/kotlin/dev/lokksmith/compose/AuthFlowLauncher.kt
@@ -62,6 +62,13 @@ internal constructor(
              * the system browser. Just like a private browsing session.
              */
             public val ephemeralBrowsing: Boolean = false,
+
+            /**
+             * Called after the `Intent` for launching the Auth / Custom Tab is created and before
+             * it is executed. Allows customization of the `Intent` if needed. The parameter is
+             * [Any] due to multiplatform constraints and must be cast to `Intent` on Android.
+             */
+            public val onIntentCreated: (Any) -> Unit = {},
         ) {
             public sealed interface Method {
 


### PR DESCRIPTION
This PR adds a callback for Android which is called after the `Intent` for launching an Auth / Custom Tab was created. It allows customizing the `Intent` if needed.