### PR TITLE
feat: add use case for token refresh or reset

### DIFF
--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -240,6 +240,7 @@ public interface Client {
      * @throws dev.lokksmith.client.request.token.TokenValidationException if the tokens could not
      *   be validated
      * @see runWithTokens
+     * @see dev.lokksmith.client.usecase.RefreshTokensOrResetUseCase
      */
     public suspend fun refresh(): Tokens
 

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/Constants.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/Constants.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Sven Jacobs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.lokksmith.client.usecase
+
+import dev.lokksmith.client.request.OAuthError
+
+internal val DEFAULT_ERRORS = listOf(OAuthError.InvalidGrant)

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/RefreshTokensOrResetUseCase.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/RefreshTokensOrResetUseCase.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Sven Jacobs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.lokksmith.client.usecase
+
+import dev.lokksmith.client.Client
+import dev.lokksmith.client.Client.Tokens
+import dev.lokksmith.client.request.OAuthError
+import dev.lokksmith.client.request.OAuthResponseException
+
+/**
+ * Executes [Client.refresh] and logs out the client locally if the OpenID provider considers the
+ * tokens invalid (e.g., returns `invalid_grant`).
+ *
+ * This use case wraps [Client.refresh], attempting to refresh the [Tokens]. If the OpenID provider
+ * responds with an OAuth error matching one of [errors] (by default, only `invalid_grant`), the
+ * client’s local session is reset via [Client.resetTokens], effectively logging out the user on
+ * this device. Other exceptions or errors are not handled and will be rethrown.
+ *
+ * Typical usage is to ensure that if the user's session is revoked or otherwise invalidated on the
+ * provider, the local client state is kept in sync by removing tokens and requiring
+ * re-authentication.
+ *
+ * @param client The client instance to operate on.
+ * @param errors List of OAuth error values that should trigger a local logout. Defaults to
+ *   `invalid_grant`.
+ * @see Client.refreshOrReset
+ * @see Client.refresh
+ * @see Client.resetTokens
+ * @see RunWithTokensOrResetUseCase
+ */
+public class RefreshTokensOrResetUseCase(
+    private val client: Client,
+    private val errors: List<OAuthError> = DEFAULT_ERRORS,
+) {
+
+    /**
+     * See [class documentation][RefreshTokensOrResetUseCase] for details.
+     *
+     * @return `true` if refresh was executed successfully; `false` if the client was logged out
+     *   locally.
+     * @see RefreshTokensOrResetUseCase
+     */
+    public suspend operator fun invoke(): Boolean {
+        try {
+            client.refresh()
+            return true
+        } catch (e: OAuthResponseException) {
+            if (errors.contains(e.error)) {
+                client.resetTokens()
+                return false
+            }
+            throw e
+        }
+    }
+}
+
+/**
+ * Convenience function for [RefreshTokensOrResetUseCase].
+ *
+ * @return `true` if refresh was executed successfully; `false` if the client was logged out
+ *   locally.
+ * @see RefreshTokensOrResetUseCase.invoke
+ */
+public suspend fun Client.refreshOrReset(errors: List<OAuthError> = DEFAULT_ERRORS): Boolean =
+    RefreshTokensOrResetUseCase(this, errors)()

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/RunWithTokensOrResetUseCase.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/usecase/RunWithTokensOrResetUseCase.kt
@@ -45,6 +45,7 @@ import dev.lokksmith.client.usecase.RunWithTokensOrResetUseCase.RunWithTokensOrR
  * @see Client.runWithTokensOrReset
  * @see Client.runWithTokens
  * @see Client.resetTokens
+ * @see RefreshTokensOrResetUseCase
  */
 public class RunWithTokensOrResetUseCase(
     private val client: Client,
@@ -98,11 +99,10 @@ public class RunWithTokensOrResetUseCase(
 /**
  * Convenience function for [RunWithTokensOrResetUseCase].
  *
+ * @return `true` if [body] was executed successfully; `false` if the client was logged out locally.
  * @see RunWithTokensOrResetUseCase.invoke
  */
 public suspend fun Client.runWithTokensOrReset(
     errors: List<OAuthError> = DEFAULT_ERRORS,
     body: suspend RunWithTokensOrResetScope.(Tokens) -> Unit,
 ): Boolean = RunWithTokensOrResetUseCase(this, errors)(body)
-
-private val DEFAULT_ERRORS = listOf(OAuthError.InvalidGrant)


### PR DESCRIPTION
This PR adds a `RefreshTokensOrResetUseCase`, similar to `RunWithTokensOrResetUseCase`, which calls `refresh()` and resets the tokens in case of an expected OAuth error.