### PR TITLE
chore: strip v-prefix from release names and disable commitlint body-max-line-length

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,15 @@ jobs:
           client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+      - name: Strip v-prefix from release name
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          TAG="${{ steps.release.outputs.tag_name }}"
+          gh release edit "$TAG" --title "${TAG#v}"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,7 @@ export default {
   // Exception for the initial plan commit created by the AI coding agent
   ignores: [(commit) => ['input: Initial plan', 'Initial plan'].includes(commit.trim())],
   rules: {
-    'header-max-length': [1, 'always', 100]
+    'header-max-length': [1, 'always', 100],
+    'body-max-line-length': [0, 'always', 100]
   }
 };


### PR DESCRIPTION
## Summary

- Release-please workflow now strips the `v` prefix from GitHub release titles (tags remain `v1.y.z`)
- Disabled the `body-max-line-length` commitlint rule

## Test plan

- [ ] Verify next release has tag `vX.Y.Z` and release name `X.Y.Z`
- [ ] Verify commits with long body lines pass commitlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)