### PR TITLE
fix: pass --repo to gh release edit to avoid missing git context

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,4 +34,4 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           TAG="${{ steps.release.outputs.tag_name }}"
-          gh release edit "$TAG" --title "${TAG#v}"
+          gh release edit "$TAG" --repo "${{ github.repository }}" --title "${TAG#v}"


### PR DESCRIPTION
## Summary

- The strip-v-prefix release step was failing because `gh release edit` tried to infer the repo from a local git checkout, which doesn't exist in that workflow step
- Passes `--repo ${{ github.repository }}` explicitly so `gh` knows which repo to target

## Test plan

- [ ] Verify next release has tag `vX.Y.Z` and release name `X.Y.Z` without the workflow step failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)