### PR TITLE
fix: allow release-please bot to trigger Update Dependency Matrix workflow

### DIFF
--- a/.github/workflows/update-dependency-matrix.lock.yml
+++ b/.github/workflows/update-dependency-matrix.lock.yml
@@ -985,6 +985,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
+          GH_AW_ALLOWED_BOTS: lokksmith-release-please[bot]
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/update-dependency-matrix.md
+++ b/.github/workflows/update-dependency-matrix.md
@@ -2,6 +2,8 @@
 on:
   release:
     types: [published]
+  bots:
+    - lokksmith-release-please[bot]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `lokksmith-release-please[bot]` to `on.bots` in the workflow frontmatter so the gh-aw pre-activation check allows the bot to trigger the workflow
- Patches the compiled lock file to pass `GH_AW_ALLOWED_BOTS` to the `check_membership` step

> **Note:** The lock file is auto-generated (`DO NOT EDIT`). Ideally `gh aw compile` should be run after merging to get a clean regeneration. The manual patch here mirrors what the compiler would produce for the `bots` frontmatter key.

## Test plan

- [ ] Verify next release triggers the Update Dependency Matrix workflow without an access-denied error

🤖 Generated with [Claude Code](https://claude.com/claude-code)