### PR TITLE
chore: rename legacy ABI tasks to Kotlin ABI

### DIFF
--- a/.github/workflows/pull-request-lib.yml
+++ b/.github/workflows/pull-request-lib.yml
@@ -27,7 +27,7 @@ jobs:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
           restore-keys: ${{ runner.os }}-konan
-      - run: ./gradlew check checkLegacyAbi
+      - run: ./gradlew check checkKotlinAbi
         working-directory: ./lib
       - name: Store reports
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ All library commands run **inside the `lib` folder**:
 
 ```bash
 ./gradlew spotlessApply        # Format code — REQUIRED after any code change
-./gradlew updateLegacyAbi      # Update ABI dump files — REQUIRED after any public API change
+./gradlew updateKotlinAbi      # Update ABI dump files — REQUIRED after any public API change
 ./gradlew check                # Run all checks (tests + spotlessCheck + ABI validation)
 ./gradlew test                 # Run all unit tests across targets
 ./gradlew :lokksmith-core:jvmTest                       # Tests for one target
@@ -29,7 +29,7 @@ All library commands run **inside the `lib` folder**:
 ```
 
 CI verifies both code style (`spotlessCheck`) and the committed ABI dumps, so run `spotlessApply`
-and `updateLegacyAbi` before committing — otherwise the build will fail.
+and `updateKotlinAbi` before committing — otherwise the build will fail.
 
 Git commit hooks (commitlint + spotless via husky) are installed by running `npm install` in the
 repository root.


### PR DESCRIPTION
Renames the Gradle ABI task references from the deprecated `LegacyAbi`
naming to `KotlinAbi` in CI and documentation.

- `.github/workflows/pull-request-lib.yml`: `checkLegacyAbi` → `checkKotlinAbi`
- `AGENTS.md`: `updateLegacyAbi` → `updateKotlinAbi` (×2)