### PR TITLE
fix: seed snapshot nonce in Migration.setTokens

### DIFF
--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Migration.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Migration.kt
@@ -58,7 +58,8 @@ internal constructor(
      * @param refreshToken The refresh token string to set, or `null` if not available.
      * @param refreshTokenExpiresAt The expiration timestamp (epoch seconds) for the refresh token,
      *   or `null` if not applicable.
-     * @param idToken The ID token string to set (JWT-encoded).
+     * @param idToken The ID token string to set (JWT-encoded). Its `nonce` claim, if present, is
+     *   remembered so that refresh responses echoing the nonce can be validated.
      * @param setMigratedFlag Sets the migrated flag on this client instance. Any further migration
      *   attempt will throw an exception.
      * @throws IllegalStateException if the client was already migrated
@@ -98,7 +99,8 @@ internal constructor(
                                 )
                             },
                         idToken = idToken,
-                    )
+                    ),
+                nonce = idToken.nonce,
             )
         }
 

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/MigrationTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/MigrationTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MigrationTest {
@@ -71,6 +72,38 @@ class MigrationTest {
         assertEquals(TEST_INSTANT + 600, tokens?.idToken?.expiration)
         assertEquals(TEST_INSTANT, tokens?.idToken?.issuedAt)
         assertContains(tokens?.idToken?.audiences.orEmpty(), "clientId")
+    }
+
+    @Test
+    fun `setTokens should set nonce from ID token on snapshot`() = runTest {
+        val client = createTestClient()
+        val idTokenWithNonce =
+            Jwt(
+                header = idToken.header,
+                payload =
+                    Jwt.Payload(
+                        iss = idToken.payload.iss,
+                        sub = idToken.payload.sub,
+                        aud = idToken.payload.aud,
+                        exp = idToken.payload.exp,
+                        iat = idToken.payload.iat,
+                        extra = mapOf("nonce" to JsonPrimitive("BHUnfLbJTz1")),
+                    ),
+            )
+
+        migration.setTokens(
+            client = client,
+            accessToken = "eosvcZMZq7e",
+            accessTokenExpiresAt = TEST_INSTANT + 600,
+            refreshToken = "m3h8Gu2r",
+            refreshTokenExpiresAt = TEST_INSTANT + 1_209_600,
+            idToken = jwtEncoder.encode(idTokenWithNonce),
+        )
+
+        runCurrent()
+
+        assertEquals("BHUnfLbJTz1", client.snapshots.value.nonce)
+        assertEquals("BHUnfLbJTz1", client.tokens.value?.idToken?.nonce)
     }
 
     @Test


### PR DESCRIPTION
## TL;DR

`Migration.setTokens` wrote the tokens but left `Snapshot.nonce` at `null`, so the first refresh of
a migrated session failed with `nonce mismatch` against providers that echo the nonce in refreshed
ID tokens. The decoded ID token already carries the value, so it is now carried over into the
snapshot — no API change, nothing for callers to do.

Closes #497

## Testing

`./gradlew :lokksmith-core:jvmTest --tests "*MigrationTest*"` in `lib` — the new test asserts the
snapshot nonce and fails without the fix.

Note: `./gradlew check` fails locally on `:lokksmith-core:wasmJsBrowserTest` ("did not discover any
tests"); this also fails on a clean checkout here and is unrelated to this change.

_Code in this pull request was generated by Claude Code (Claude Opus 5)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)