### PR TITLE
feat: allow additional parameters on token requests

### DIFF
--- a/lib/lokksmith-core/api/jvm/lokksmith-core.api
+++ b/lib/lokksmith-core/api/jvm/lokksmith-core.api
@@ -192,13 +192,15 @@ public final class dev/lokksmith/client/Client$Metadata$Companion {
 
 public final class dev/lokksmith/client/Client$Options {
 	public fun <init> ()V
-	public fun <init> (II)V
-	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IILjava/util/Map;)V
+	public synthetic fun <init> (IILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun copy (II)Ldev/lokksmith/client/Client$Options;
-	public static synthetic fun copy$default (Ldev/lokksmith/client/Client$Options;IIILjava/lang/Object;)Ldev/lokksmith/client/Client$Options;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (IILjava/util/Map;)Ldev/lokksmith/client/Client$Options;
+	public static synthetic fun copy$default (Ldev/lokksmith/client/Client$Options;IILjava/util/Map;ILjava/lang/Object;)Ldev/lokksmith/client/Client$Options;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalTokenRequestParameters ()Ljava/util/Map;
 	public final fun getLeewaySeconds ()I
 	public final fun getPreemptiveRefreshSeconds ()I
 	public fun hashCode ()I

--- a/lib/lokksmith-core/api/lokksmith-core.klib.api
+++ b/lib/lokksmith-core/api/lokksmith-core.klib.api
@@ -219,8 +219,10 @@ abstract interface dev.lokksmith.client/Client { // dev.lokksmith.client/Client|
     }
 
     final class Options { // dev.lokksmith.client/Client.Options|null[0]
-        constructor <init>(kotlin/Int = ..., kotlin/Int = ...) // dev.lokksmith.client/Client.Options.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+        constructor <init>(kotlin/Int = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...) // dev.lokksmith.client/Client.Options.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
 
+        final val additionalTokenRequestParameters // dev.lokksmith.client/Client.Options.additionalTokenRequestParameters|{}additionalTokenRequestParameters[0]
+            final fun <get-additionalTokenRequestParameters>(): kotlin.collections/Map<kotlin/String, kotlin/String> // dev.lokksmith.client/Client.Options.additionalTokenRequestParameters.<get-additionalTokenRequestParameters>|<get-additionalTokenRequestParameters>(){}[0]
         final val leewaySeconds // dev.lokksmith.client/Client.Options.leewaySeconds|{}leewaySeconds[0]
             final fun <get-leewaySeconds>(): kotlin/Int // dev.lokksmith.client/Client.Options.leewaySeconds.<get-leewaySeconds>|<get-leewaySeconds>(){}[0]
         final val preemptiveRefreshSeconds // dev.lokksmith.client/Client.Options.preemptiveRefreshSeconds|{}preemptiveRefreshSeconds[0]
@@ -228,7 +230,8 @@ abstract interface dev.lokksmith.client/Client { // dev.lokksmith.client/Client|
 
         final fun component1(): kotlin/Int // dev.lokksmith.client/Client.Options.component1|component1(){}[0]
         final fun component2(): kotlin/Int // dev.lokksmith.client/Client.Options.component2|component2(){}[0]
-        final fun copy(kotlin/Int = ..., kotlin/Int = ...): dev.lokksmith.client/Client.Options // dev.lokksmith.client/Client.Options.copy|copy(kotlin.Int;kotlin.Int){}[0]
+        final fun component3(): kotlin.collections/Map<kotlin/String, kotlin/String> // dev.lokksmith.client/Client.Options.component3|component3(){}[0]
+        final fun copy(kotlin/Int = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): dev.lokksmith.client/Client.Options // dev.lokksmith.client/Client.Options.copy|copy(kotlin.Int;kotlin.Int;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // dev.lokksmith.client/Client.Options.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // dev.lokksmith.client/Client.Options.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // dev.lokksmith.client/Client.Options.toString|toString(){}[0]

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -26,6 +26,7 @@ import dev.lokksmith.client.request.flow.IdentityRedirectUriHandler
 import dev.lokksmith.client.request.flow.RedirectUriHandler
 import dev.lokksmith.client.request.flow.authorizationCode.AuthorizationCodeFlow
 import dev.lokksmith.client.request.flow.endSession.EndSessionFlow
+import dev.lokksmith.client.request.parameter.Parameter
 import dev.lokksmith.client.request.refresh.RefreshTokenRequest
 import dev.lokksmith.client.request.refresh.RefreshTokenRequestImpl
 import dev.lokksmith.client.snapshot.InternalSnapshotStore
@@ -131,11 +132,41 @@ public interface Client {
          * @see leewaySeconds
          */
         val preemptiveRefreshSeconds: Int = 60,
+
+        /**
+         * Additional parameters sent with every request to the token endpoint, both the
+         * authorization code exchange and the token refresh.
+         *
+         * Some providers require a vendor-specific parameter on token requests. For example, SAP
+         * Customer Data Cloud answers token endpoint errors with HTTP 200 and an error body unless
+         * `httpStatusCodes=true` is sent, which prevents an OAuth error from being distinguished
+         * from a malformed response.
+         *
+         * Known OAuth and OIDC parameters are rejected, so this cannot be used to tamper with
+         * `grant_type`, `client_id`, `code`, `code_verifier`, `redirect_uri` or `refresh_token`.
+         * This mirrors the behaviour of `AuthFlow.Request.additionalParameters`, except that it is
+         * validated when the options are constructed rather than when a request is sent.
+         *
+         * These parameters are constant for the lifetime of the client. Values that vary per
+         * request are not covered by this option.
+         *
+         * @throws IllegalArgumentException if a key is blank or is a known OAuth/OIDC parameter
+         */
+        val additionalTokenRequestParameters: Map<String, String> = emptyMap(),
     ) {
         init {
             require(leewaySeconds >= 0) { "leewaySeconds must be a positive value" }
             require(preemptiveRefreshSeconds >= 0) {
                 "preemptiveRefreshSeconds must be a positive value"
+            }
+
+            additionalTokenRequestParameters.keys.forEach { key ->
+                require(key.isNotBlank()) {
+                    "additionalTokenRequestParameters must not contain blank keys"
+                }
+                require(!Parameter.KNOWN_PARAMETERS.contains(key.lowercase())) {
+                    "Parameter \"$key\" is a known OAuth/OIDC parameter"
+                }
             }
         }
     }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -144,8 +144,9 @@ public interface Client {
          *
          * Known OAuth and OIDC parameters are rejected, so this cannot be used to tamper with
          * `grant_type`, `client_id`, `code`, `code_verifier`, `redirect_uri` or `refresh_token`.
-         * This mirrors the behaviour of `AuthFlow.Request.additionalParameters`, except that it is
-         * validated when the options are constructed rather than when a request is sent.
+         * This is checked twice, like `AuthFlow.Request.additionalParameters`: once here when the
+         * options are constructed, and again when a request is sent. A client takes a defensive
+         * copy of this map, so mutating it afterwards changes nothing.
          *
          * These parameters are constant for the lifetime of the client. Values that vary per
          * request are not covered by this option.
@@ -416,12 +417,23 @@ public interface InternalClient : Client {
 internal class ClientImpl
 private constructor(
     override val key: Key,
-    override var options: Client.Options,
+    options: Client.Options,
     override val tokens: StateFlow<Tokens?>,
     override val provider: Provider,
     private val snapshotContract: SnapshotContract,
     internal val coroutineScope: CoroutineScope,
 ) : InternalClient {
+
+    /**
+     * Assigned through [withDefensivelyCopiedParameters] so that [Client.Options] held by a client
+     * never shares [Client.Options.additionalTokenRequestParameters] with the caller. Validation in
+     * `Options.init` happens once, at construction; without the copy a caller could mutate the map
+     * afterwards and change what is sent to the token endpoint.
+     */
+    override var options: Client.Options = options.withDefensivelyCopiedParameters()
+        set(value) {
+            field = value.withDefensivelyCopiedParameters()
+        }
 
     internal class DefaultProvider(
         private val httpClient: HttpClient,
@@ -575,3 +587,13 @@ private constructor(
         }
     }
 }
+
+/**
+ * Returns options holding an immutable copy of [Client.Options.additionalTokenRequestParameters].
+ *
+ * `copy()` re-runs `init`, so the returned options are validated as well as isolated from the
+ * caller. The copy is unconditional: a map that is empty when a client is created may not be empty
+ * later.
+ */
+private fun Client.Options.withDefensivelyCopiedParameters(): Client.Options =
+    copy(additionalTokenRequestParameters = additionalTokenRequestParameters.toMap())

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenRequest.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenRequest.kt
@@ -83,14 +83,21 @@ public class TokenRequest(private val client: Client, private val httpClient: Ht
 }
 
 /**
- * Appends [additionalParameters] to the request.
+ * Appends [additionalParameters] to the request, rejecting any key the request already carries.
  *
- * No collision check is needed here: [Client.Options] rejects known OAuth/OIDC parameters when it
- * is constructed, and every parameter these requests send is one. Checking again at send time would
- * only hide a validation gap.
+ * [Client.Options] validates its parameters against the known OAuth/OIDC parameters when it is
+ * constructed, which covers everything these requests send today. This check is not redundant with
+ * that one: it covers a different moment in time, and it keeps the guarantee intact for a future
+ * call site that appends a parameter the constructor-time list does not know about.
+ *
+ * Rejecting rather than skipping matters because form parameters are a multimap — appending a
+ * duplicate `grant_type` would send both values and leave the choice between them to the server.
  */
 private fun ParametersBuilder.appendAdditionalParameters(
     additionalParameters: Map<String, String>
 ) {
-    additionalParameters.forEach { (name, value) -> append(name, value) }
+    additionalParameters.forEach { (name, value) ->
+        require(!contains(name)) { "Parameter \"$name\" is already present" }
+        append(name, value)
+    }
 }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenRequest.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenRequest.kt
@@ -32,12 +32,17 @@ import kotlinx.coroutines.withContext
 public class TokenRequest(private val client: Client, private val httpClient: HttpClient) {
 
     public suspend operator fun invoke(builder: ParametersBuilder.() -> Unit): TokenResponse {
+        val formParameters = Parameters.build {
+            builder()
+            appendAdditionalParameters(client.options.additionalTokenRequestParameters)
+        }
+
         val response =
             try {
                 withContext(ioDispatcher) {
                     httpClient.submitForm(
                         url = client.metadata.tokenEndpoint,
-                        formParameters = Parameters.build(builder),
+                        formParameters = formParameters,
                     )
                 }
             } catch (e: CancellationException) {
@@ -75,4 +80,17 @@ public class TokenRequest(private val client: Client, private val httpClient: Ht
 
         return tokenResponse
     }
+}
+
+/**
+ * Appends [additionalParameters] to the request.
+ *
+ * No collision check is needed here: [Client.Options] rejects known OAuth/OIDC parameters when it
+ * is constructed, and every parameter these requests send is one. Checking again at send time would
+ * only hide a validation gap.
+ */
+private fun ParametersBuilder.appendAdditionalParameters(
+    additionalParameters: Map<String, String>
+) {
+    additionalParameters.forEach { (name, value) -> append(name, value) }
 }

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -374,6 +374,103 @@ class ClientTest {
         client.dispose()
         assertFalse((client as ClientImpl).coroutineScope.isActive)
     }
+
+    @Test
+    fun `refresh should send additional token request parameters`() = runTest {
+        val jwtEncoder = JwtEncoder(Json)
+        val engine = MockEngine { request ->
+            when (request.url.toString()) {
+                "https://example.com/tokenEndpoint" -> {
+                    val body = assertIs<FormDataContent>(request.body)
+
+                    assertEquals("true", body.formData["httpStatusCodes"])
+                    assertEquals("value", body.formData["vendorParam"])
+
+                    // Protocol parameters are still sent, exactly once each.
+                    assertEquals(
+                        listOf(GrantType.RefreshToken.value),
+                        body.formData.getAll(Parameter.GRANT_TYPE),
+                    )
+                    assertEquals(listOf("clientId"), body.formData.getAll(Parameter.CLIENT_ID))
+                    assertEquals(listOf("bMGysPYch"), body.formData.getAll(Parameter.REFRESH_TOKEN))
+
+                    val idToken =
+                        Jwt(
+                            header = Jwt.Header(alg = "none"),
+                            payload =
+                                Jwt.Payload(
+                                    iss = "issuer",
+                                    sub = "8582ce26-3994-42e7-afb0-39d42e18fd1f",
+                                    aud = listOf("clientId"),
+                                    exp = 1748706999 + 600,
+                                    iat = 1748706999,
+                                    extra = mapOf("nonce" to JsonPrimitive("0D1ck61")),
+                                ),
+                        )
+
+                    val response =
+                        TokenResponse(
+                            tokenType = "Bearer",
+                            accessToken = "Lh0rP8vrtQH",
+                            expiresIn = 600,
+                            refreshToken = "cyaVZ3zPU",
+                            idToken = jwtEncoder.encode(idToken),
+                        )
+
+                    respond(
+                        content = httpJson.encodeToString(response),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+                else -> respondBadRequest()
+            }
+        }
+
+        val client =
+            createTestClient(
+                provider =
+                    TestProvider(
+                        httpClient = createHttpClient(engine),
+                        timeProvider = { Instant.fromEpochSeconds(1748706999, 0) },
+                    ),
+                options =
+                    Client.Options(
+                        additionalTokenRequestParameters =
+                            mapOf("httpStatusCodes" to "true", "vendorParam" to "value")
+                    ),
+                initialSnapshot = { copy(tokens = SAMPLE_TOKENS, nonce = "0D1ck61") },
+            )
+
+        client.refresh()
+        runCurrent()
+
+        assertEquals("Lh0rP8vrtQH", assertNotNull(client.tokens.value).accessToken.token)
+    }
+
+    @Test
+    fun `Options should reject a known OAuth parameter as an additional token request parameter`() {
+        // Upper case to confirm the check is case-insensitive, as it is for authorization requests.
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                Client.Options(additionalTokenRequestParameters = mapOf("Grant_Type" to "evil"))
+            }
+
+        assertEquals("Parameter \"Grant_Type\" is a known OAuth/OIDC parameter", exception.message)
+    }
+
+    @Test
+    fun `Options should reject a blank additional token request parameter key`() {
+        assertFailsWith<IllegalArgumentException> {
+            Client.Options(additionalTokenRequestParameters = mapOf(" " to "value"))
+        }
+    }
+
+    @Test
+    fun `Options should default additional token request parameters to an empty map`() {
+        assertEquals(emptyMap(), Client.Options().additionalTokenRequestParameters)
+    }
 }
 
 internal data class TestProvider(
@@ -410,6 +507,7 @@ suspend fun TestScope.createTestClient(
     snapshotStore: SnapshotStore =
         SnapshotStoreImpl(persistence = PersistenceFake(), serializer = Json),
     provider: InternalClient.Provider = TestProvider(),
+    options: Client.Options = Client.Options(),
     initialSnapshot: Snapshot.() -> Snapshot = { this },
 ): InternalClient {
     // Create initial snapshot
@@ -432,7 +530,7 @@ suspend fun TestScope.createTestClient(
     val client =
         ClientImpl.create(
             key = key,
-            options = Client.Options(),
+            options = options,
             coroutineScope = backgroundScope,
             snapshotStore = snapshotStore,
             provider = provider,

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -471,6 +471,41 @@ class ClientTest {
     fun `Options should default additional token request parameters to an empty map`() {
         assertEquals(emptyMap(), Client.Options().additionalTokenRequestParameters)
     }
+
+    @Test
+    fun `client should not observe mutation of the additional token request parameters map`() =
+        runTest {
+            val parameters = mutableMapOf("httpStatusCodes" to "true")
+
+            val client =
+                createTestClient(
+                    options = Client.Options(additionalTokenRequestParameters = parameters)
+                )
+
+            // Passed validation as a legitimate map, then mutated to smuggle in a protocol
+            // parameter and to add an entry that was never validated.
+            parameters[Parameter.GRANT_TYPE] = "password"
+            parameters["addedLater"] = "value"
+
+            assertEquals(
+                mapOf("httpStatusCodes" to "true"),
+                client.options.additionalTokenRequestParameters,
+            )
+        }
+
+    @Test
+    fun `client should not observe mutation of parameters assigned after creation`() = runTest {
+        val parameters = mutableMapOf("httpStatusCodes" to "true")
+        val client = createTestClient()
+
+        client.options = Client.Options(additionalTokenRequestParameters = parameters)
+        parameters[Parameter.GRANT_TYPE] = "password"
+
+        assertEquals(
+            mapOf("httpStatusCodes" to "true"),
+            client.options.additionalTokenRequestParameters,
+        )
+    }
 }
 
 internal data class TestProvider(

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTest.kt
@@ -15,6 +15,7 @@
  */
 package dev.lokksmith.client.request.flow.authorizationCode
 
+import dev.lokksmith.client.Client
 import dev.lokksmith.client.Id
 import dev.lokksmith.client.InternalClient
 import dev.lokksmith.client.Key
@@ -361,6 +362,90 @@ class AuthorizationCodeFlowTest {
     }
 
     @Test
+    fun `onResponse should send additional token request parameters`() = runTest {
+        val jwtEncoder = JwtEncoder(Json)
+
+        val (flow, client, testState) =
+            createFlow(
+                options =
+                    Client.Options(
+                        additionalTokenRequestParameters = mapOf("httpStatusCodes" to "true")
+                    )
+            ) { testState ->
+                { request ->
+                    when (request.url.toString()) {
+                        "https://example.com/tokenEndpoint" -> {
+                            val body = assertIs<FormDataContent>(request.body)
+
+                            assertEquals("true", body.formData["httpStatusCodes"])
+
+                            // Protocol parameters are still sent, exactly once each.
+                            assertEquals(
+                                listOf(GrantType.AuthorizationCode.value),
+                                body.formData.getAll(Parameter.GRANT_TYPE),
+                            )
+                            assertEquals(
+                                listOf("s7FBqWPnG2"),
+                                body.formData.getAll(Parameter.CODE),
+                            )
+
+                            val idToken =
+                                Jwt(
+                                    header = Jwt.Header(alg = "none"),
+                                    payload =
+                                        Jwt.Payload(
+                                            iss = "issuer",
+                                            sub = "8582ce26-3994-42e7-afb0-39d42e18fd1f",
+                                            aud = listOf("clientId"),
+                                            exp = TEST_INSTANT + 600,
+                                            iat = TEST_INSTANT,
+                                            extra =
+                                                mapOf("nonce" to JsonPrimitive(testState.nonce)),
+                                        ),
+                                )
+
+                            val response =
+                                TokenResponse(
+                                    tokenType = "Bearer",
+                                    accessToken = "Lh0rP8vrtQH",
+                                    expiresIn = 600,
+                                    idToken = jwtEncoder.encode(idToken),
+                                )
+
+                            respond(
+                                content = httpJson.encodeToString(response),
+                                status = HttpStatusCode.OK,
+                                headers = headersOf("Content-Type", "application/json"),
+                            )
+                        }
+
+                        else -> respondBadRequest()
+                    }
+                }
+            }
+
+        flow.prepare()
+        runCurrent()
+
+        testState.codeVerifier = flow.codeVerifier
+        testState.nonce = flow.nonce
+
+        val responseUrl =
+            buildUrl {
+                    takeFrom("https://example.com/app/redirect")
+                    parameters[Parameter.STATE] = flow.state
+                    parameters[Parameter.CODE] = "s7FBqWPnG2"
+                }
+                .toString()
+
+        flow.onResponse(responseUrl)
+        runCurrent()
+
+        assertEquals("Lh0rP8vrtQH", assertNotNull(client.tokens.value).accessToken.token)
+        assertEquals(FlowResult.Success(state = flow.state), client.snapshots.value.flowResult)
+    }
+
+    @Test
     fun `onResponse should handle error in code response`() = runTest {
         val (flow, client) = createFlow()
 
@@ -548,6 +633,7 @@ private suspend fun TestScope.createFlow(
     request: AuthorizationCodeFlow.Request =
         AuthorizationCodeFlow.Request(redirectUri = "https://example.com/app/redirect"),
     redirectUriHandler: RedirectUriHandler = IdentityRedirectUriHandler,
+    options: Client.Options = Client.Options(),
     requestHandler: (TestState) -> MockRequestHandleScope.(HttpRequestData) -> HttpResponseData = {
         { respondBadRequest() }
     },
@@ -562,6 +648,7 @@ private suspend fun TestScope.createFlow(
             id = id,
             provider =
                 TestProvider(httpClient = httpClient, redirectUriHandler = { redirectUriHandler }),
+            options = options,
         )
 
     return Triple(

--- a/site/docs/getting-started/usage.md
+++ b/site/docs/getting-started/usage.md
@@ -112,9 +112,10 @@ is sent. Without it, Lokksmith cannot tell an OAuth error such as `invalid_grant
 malformed response — which is the difference between "the session is dead" and "retry later".
 
 !!! warning
-    Known OAuth and OIDC parameters are rejected with an `IllegalArgumentException` when the options
-    are constructed, so this cannot be used to override `grant_type`, `client_id`, `code`,
-    `code_verifier`, `redirect_uri` or `refresh_token`.
+    Known OAuth and OIDC parameters are rejected with an `IllegalArgumentException`, so this cannot
+    be used to override `grant_type`, `client_id`, `code`, `code_verifier`, `redirect_uri` or
+    `refresh_token`. This is checked when the options are constructed and again when a request is
+    sent, and the client keeps a defensive copy of the map, so mutating it afterwards has no effect.
 
 These parameters are constant for the lifetime of the client. Values that need to vary per request
 are not covered by this option.

--- a/site/docs/getting-started/usage.md
+++ b/site/docs/getting-started/usage.md
@@ -88,6 +88,37 @@ SingletonLokksmithProvider.set(
 )
 ```
 
+## Provider-specific token request parameters
+
+Some providers require a vendor-specific parameter on requests to the token endpoint. Set
+`additionalTokenRequestParameters` on the client options to have it sent with both the authorization
+code exchange and every token refresh:
+
+```kotlin
+val client = lokksmith.getOrCreate(
+    key = "my-key",
+    options = Client.Options(
+        additionalTokenRequestParameters = mapOf("httpStatusCodes" to "true"),
+    ),
+) {
+    id = "my-client-id"
+    discoveryUrl = "https://example.com/.well-known/openid-configuration"
+}
+```
+
+The example above is [SAP Customer Data Cloud](https://help.sap.com/docs/SAP_CUSTOMER_DATA_CLOUD),
+which answers token endpoint errors with `HTTP 200` and an error body unless `httpStatusCodes=true`
+is sent. Without it, Lokksmith cannot tell an OAuth error such as `invalid_grant` apart from a
+malformed response — which is the difference between "the session is dead" and "retry later".
+
+!!! warning
+    Known OAuth and OIDC parameters are rejected with an `IllegalArgumentException` when the options
+    are constructed, so this cannot be used to override `grant_type`, `client_id`, `code`,
+    `code_verifier`, `redirect_uri` or `refresh_token`.
+
+These parameters are constant for the lifetime of the client. Values that need to vary per request
+are not covered by this option.
+
 ## Platform-specific configuration
 
 Some request values legitimately differ per platform. The most common is the **redirect URI**: a


### PR DESCRIPTION
Closes #496.

Adds `Client.Options.additionalTokenRequestParameters`, sent with both the authorization code
exchange and every token refresh.

```kotlin
Client.Options(additionalTokenRequestParameters = mapOf("httpStatusCodes" to "true"))
```

Applied in `TokenRequest`, which both requests already funnel through.

**Collisions.** Known OAuth/OIDC parameters are rejected with `IllegalArgumentException`, so
`grant_type`, `client_id`, `code`, `code_verifier`, `redirect_uri` and `refresh_token` can't be
overridden — the same convention `addAdditionalParameters` uses for authorization requests. The one
difference is that it's validated when `Options` is constructed rather than at send time, so a
configuration mistake fails at startup instead of mid-refresh. Happy to move it if you'd rather both
paths behave identically.

**Compatibility.** Defaults to an empty map, so existing code compiles unchanged. One caveat worth
flagging: the JVM ABI of `Options` changes, as it must for a new property on a `data class`.

```
-	public fun <init> (II)V
+	public fun <init> (IILjava/util/Map;)V
```

…plus `copy` and a new `component3`. Source compatible, not binary compatible. If you want the
latter, `@Poko` instead of `data` or a builder would do it — both bigger changes than this warrants,
so I've left it for you to decide. ABI dumps are updated.

**Not included.** `scope` ([RFC 6749 §6](https://www.rfc-editor.org/rfc/rfc6749#section-6)) and
`resource` ([RFC 8707 §2.2](https://www.rfc-editor.org/rfc/rfc8707#section-2.2)) vary per request
rather than per client, so they need arguments on `refresh()` and the flow request — worth agreeing
separately. Note RFC 8707 permits *multiple* `resource` values, so `Map<String, String>` won't fit
that case.

**Naming.** `additionalTokenRequestParameters` rather than `additionalParameters`, since `Options`
isn't request-scoped and `AuthFlow.Request.additionalParameters` already means something else.
Rename if you prefer.

**Tests.** Four in `ClientTest`: a refresh sends the parameters and still sends each protocol
parameter exactly once (asserted with `getAll`, so a duplicate would fail); a known parameter is
rejected, in mixed case to cover the case-insensitive check; a blank key is rejected; the default is
an empty map. I confirmed the first fails when the `TokenRequest` call is removed rather than passing
vacuously.

`:lokksmith-core:jvmTest spotlessCheck checkKotlinAbi` passes — 209 tests. I couldn't run the full
`check`: the iOS simulator test link fails on my machine on `main` as well, under Xcode 26.6 with
missing Swift compatibility libraries. Looks like a local toolchain issue rather than anything here.

Docs: a new section in `usage.md`.

---

**AI disclosure:** this description, the implementation and the tests were written with the help of
Claude (Claude Code, Opus 5), with me directing and reviewing. The commit message says the same and
carries a `Co-Authored-By: Claude Opus 5` trailer.
