### PR TITLE
fix: read refresh grant from the store instead of a lagging StateFlow

### DIFF
--- a/lib/lokksmith-core/api/jvm/lokksmith-core.api
+++ b/lib/lokksmith-core/api/jvm/lokksmith-core.api
@@ -388,6 +388,7 @@ public final class dev/lokksmith/client/IdKt {
 }
 
 public abstract interface class dev/lokksmith/client/InternalClient : dev/lokksmith/client/Client {
+	public abstract fun currentSnapshot (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getProvider ()Ldev/lokksmith/client/InternalClient$Provider;
 	public abstract fun getSnapshots ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun updateSnapshot (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -406,6 +407,8 @@ public final class dev/lokksmith/client/InternalClient$Provider$DefaultImpls {
 }
 
 public abstract interface class dev/lokksmith/client/InternalClient$SnapshotContract {
+	public abstract fun currentSnapshot (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getRefreshMutex ()Lkotlinx/coroutines/sync/Mutex;
 	public abstract fun getSnapshots ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun updateSnapshot (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1218,7 +1221,7 @@ public abstract class dev/lokksmith/client/request/token/TokenResponseValidator 
 	public final fun validate (Ldev/lokksmith/client/request/token/TokenResponse;Ldev/lokksmith/client/Client$Tokens$IdToken;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun validate$default (Ldev/lokksmith/client/request/token/TokenResponseValidator;Ldev/lokksmith/client/request/token/TokenResponse;Ldev/lokksmith/client/Client$Tokens$IdToken;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	protected fun validateAuthTime (Ldev/lokksmith/client/Client$Tokens$IdToken;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected abstract fun validateIdTokenNonce (Ldev/lokksmith/client/Client$Tokens$IdToken;)V
+	protected abstract fun validateIdTokenNonce (Ldev/lokksmith/client/Client$Tokens$IdToken;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class dev/lokksmith/client/request/token/TokenResponseValidator$Result {

--- a/lib/lokksmith-core/api/lokksmith-core.klib.api
+++ b/lib/lokksmith-core/api/lokksmith-core.klib.api
@@ -405,6 +405,7 @@ abstract interface dev.lokksmith.client/InternalClient : dev.lokksmith.client/Cl
     abstract val snapshots // dev.lokksmith.client/InternalClient.snapshots|{}snapshots[0]
         abstract fun <get-snapshots>(): kotlinx.coroutines.flow/StateFlow<dev.lokksmith.client.snapshot/Snapshot> // dev.lokksmith.client/InternalClient.snapshots.<get-snapshots>|<get-snapshots>(){}[0]
 
+    abstract suspend fun currentSnapshot(): dev.lokksmith.client.snapshot/Snapshot // dev.lokksmith.client/InternalClient.currentSnapshot|currentSnapshot(){}[0]
     abstract suspend fun updateSnapshot(kotlin/Function1<dev.lokksmith.client.snapshot/Snapshot, dev.lokksmith.client.snapshot/Snapshot>): dev.lokksmith.client.snapshot/Snapshot // dev.lokksmith.client/InternalClient.updateSnapshot|updateSnapshot(kotlin.Function1<dev.lokksmith.client.snapshot.Snapshot,dev.lokksmith.client.snapshot.Snapshot>){}[0]
 
     abstract interface Provider { // dev.lokksmith.client/InternalClient.Provider|null[0]
@@ -421,9 +422,12 @@ abstract interface dev.lokksmith.client/InternalClient : dev.lokksmith.client/Cl
     }
 
     abstract interface SnapshotContract { // dev.lokksmith.client/InternalClient.SnapshotContract|null[0]
+        abstract val refreshMutex // dev.lokksmith.client/InternalClient.SnapshotContract.refreshMutex|{}refreshMutex[0]
+            abstract fun <get-refreshMutex>(): kotlinx.coroutines.sync/Mutex // dev.lokksmith.client/InternalClient.SnapshotContract.refreshMutex.<get-refreshMutex>|<get-refreshMutex>(){}[0]
         abstract val snapshots // dev.lokksmith.client/InternalClient.SnapshotContract.snapshots|{}snapshots[0]
             abstract fun <get-snapshots>(): kotlinx.coroutines.flow/StateFlow<dev.lokksmith.client.snapshot/Snapshot> // dev.lokksmith.client/InternalClient.SnapshotContract.snapshots.<get-snapshots>|<get-snapshots>(){}[0]
 
+        abstract suspend fun currentSnapshot(): dev.lokksmith.client.snapshot/Snapshot // dev.lokksmith.client/InternalClient.SnapshotContract.currentSnapshot|currentSnapshot(){}[0]
         abstract suspend fun updateSnapshot(kotlin/Function1<dev.lokksmith.client.snapshot/Snapshot, dev.lokksmith.client.snapshot/Snapshot>): dev.lokksmith.client.snapshot/Snapshot // dev.lokksmith.client/InternalClient.SnapshotContract.updateSnapshot|updateSnapshot(kotlin.Function1<dev.lokksmith.client.snapshot.Snapshot,dev.lokksmith.client.snapshot.Snapshot>){}[0]
     }
 }
@@ -639,7 +643,7 @@ abstract class <#A: dev.lokksmith.client/Client.Tokens.IdToken?> dev.lokksmith.c
         final fun <get-client>(): dev.lokksmith.client/InternalClient // dev.lokksmith.client.request.token/TokenResponseValidator.client.<get-client>|<get-client>(){}[0]
 
     abstract fun getIdToken(dev.lokksmith.client.request.token/TokenResponse): #A // dev.lokksmith.client.request.token/TokenResponseValidator.getIdToken|getIdToken(dev.lokksmith.client.request.token.TokenResponse){}[0]
-    abstract fun validateIdTokenNonce(dev.lokksmith.client/Client.Tokens.IdToken) // dev.lokksmith.client.request.token/TokenResponseValidator.validateIdTokenNonce|validateIdTokenNonce(dev.lokksmith.client.Client.Tokens.IdToken){}[0]
+    abstract suspend fun validateIdTokenNonce(dev.lokksmith.client/Client.Tokens.IdToken) // dev.lokksmith.client.request.token/TokenResponseValidator.validateIdTokenNonce|validateIdTokenNonce(dev.lokksmith.client.Client.Tokens.IdToken){}[0]
     final fun decodeIdToken(kotlin/String): dev.lokksmith.client/Client.Tokens.IdToken // dev.lokksmith.client.request.token/TokenResponseValidator.decodeIdToken|decodeIdToken(kotlin.String){}[0]
     final suspend fun validate(dev.lokksmith.client.request.token/TokenResponse, dev.lokksmith.client/Client.Tokens.IdToken? = ...): dev.lokksmith.client.request.token/TokenResponseValidator.Result<#A> // dev.lokksmith.client.request.token/TokenResponseValidator.validate|validate(dev.lokksmith.client.request.token.TokenResponse;dev.lokksmith.client.Client.Tokens.IdToken?){}[0]
     open suspend fun validateAuthTime(dev.lokksmith.client/Client.Tokens.IdToken) // dev.lokksmith.client.request.token/TokenResponseValidator.validateAuthTime|validateAuthTime(dev.lokksmith.client.Client.Tokens.IdToken){}[0]

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/Client.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -379,7 +381,16 @@ public interface InternalClient : Client {
 
         public val snapshots: StateFlow<Snapshot>
 
+        /**
+         * Serializes [ClientImpl.refresh] across every [ClientImpl] instance created for this key,
+         * since [Lokksmith.get] hands out a new instance per call over the same store.
+         */
+        public val refreshMutex: Mutex
+
         public suspend fun updateSnapshot(body: Snapshot.() -> Snapshot): Snapshot
+
+        /** Reads the current snapshot directly from the store, bypassing [snapshots]' lag. */
+        public suspend fun currentSnapshot(): Snapshot
     }
 
     /**
@@ -412,6 +423,9 @@ public interface InternalClient : Client {
     public val snapshots: StateFlow<Snapshot>
 
     public suspend fun updateSnapshot(body: Snapshot.() -> Snapshot): Snapshot
+
+    /** Reads the current snapshot directly from the store, bypassing [snapshots]' lag. */
+    public suspend fun currentSnapshot(): Snapshot
 }
 
 internal class ClientImpl
@@ -474,31 +488,39 @@ private constructor(
             coroutineScope.launch { updateSnapshot { copy(metadata = value) } }
         }
 
-    override suspend fun refresh(): Tokens {
-        val tokens =
-            checkNotNull(snapshots.value.tokens) { "Client not authenticated (tokens are null)" }
-        check(tokens.accessToken.expiresAt == null || tokens.refreshToken != null) {
-            "access token has expiration but refresh token is missing"
+    // Held across the read, the network request and the write so that a second concurrent caller
+    // observes the rotated refresh token instead of replaying the one the first caller already
+    // spent. Deliberately not writeMutex: that one is taken inside updateSnapshot, so reusing it
+    // here would deadlock, and it would otherwise block unrelated clients' writes for the length
+    // of a network call.
+    override suspend fun refresh(): Tokens =
+        snapshotContract.refreshMutex.withLock {
+            val tokens =
+                checkNotNull(currentSnapshot().tokens) {
+                    "Client not authenticated (tokens are null)"
+                }
+            check(tokens.accessToken.expiresAt == null || tokens.refreshToken != null) {
+                "access token has expiration but refresh token is missing"
+            }
+
+            val refreshTokenRequest = provider.refreshTokenRequest(this)
+            val response = refreshTokenRequest()
+
+            val refreshedTokens =
+                Tokens(
+                    accessToken = response.accessToken,
+                    refreshToken = response.refreshToken ?: tokens.refreshToken,
+                    idToken = response.idToken ?: tokens.idToken,
+                )
+
+            updateSnapshot { copy(tokens = refreshedTokens) }
+
+            refreshedTokens
         }
-
-        val refreshTokenRequest = provider.refreshTokenRequest(this)
-        val response = refreshTokenRequest()
-
-        val refreshedTokens =
-            Tokens(
-                accessToken = response.accessToken,
-                refreshToken = response.refreshToken ?: tokens.refreshToken,
-                idToken = response.idToken ?: tokens.idToken,
-            )
-
-        updateSnapshot { copy(tokens = refreshedTokens) }
-
-        return refreshedTokens
-    }
 
     override suspend fun runWithTokens(body: suspend (Tokens) -> Unit) {
         val currentTokens =
-            checkNotNull(snapshots.value.tokens) { "Client not authenticated (tokens are null)" }
+            checkNotNull(currentSnapshot().tokens) { "Client not authenticated (tokens are null)" }
         val validTokens =
             when {
                 currentTokens.areExpired(
@@ -540,6 +562,8 @@ private constructor(
 
     override suspend fun updateSnapshot(body: Snapshot.() -> Snapshot) =
         snapshotContract.updateSnapshot(body)
+
+    override suspend fun currentSnapshot(): Snapshot = snapshotContract.currentSnapshot()
 
     override fun dispose() {
         coroutineScope.cancel()

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlow.kt
@@ -174,6 +174,7 @@ private constructor(
     override suspend fun onPrepare(redirectUri: String): String {
         val codeChallengeStrategy =
             CodeChallengeStrategy.create(request.codeChallengeMethod, codeVerifier)
+        val idTokenHint = client.currentSnapshot().tokens?.idToken?.raw
 
         return try {
             buildUrl {
@@ -192,10 +193,7 @@ private constructor(
                     addOptionalParameter(Parameter.PROMPT, request.prompt)
                     addOptionalParameter(Parameter.MAX_AGE, request.maxAge)
                     addOptionalParameter(Parameter.UI_LOCALES, request.uiLocales)
-                    addOptionalParameter(
-                        Parameter.ID_TOKEN_HINT,
-                        client.snapshots.value.tokens?.idToken?.raw,
-                    )
+                    addOptionalParameter(Parameter.ID_TOKEN_HINT, idTokenHint)
                     addOptionalParameter(Parameter.LOGIN_HINT, request.loginHint)
                     addAdditionalParameters(request.additionalParameters)
                 }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowResponseHandler.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowResponseHandler.kt
@@ -86,8 +86,8 @@ public class AuthorizationCodeFlowResponseHandler(
         }
     }
 
-    private fun readRedirectUriFromSnapshot(): String {
-        val ephemeral = client.snapshots.value.ephemeralFlowState
+    private suspend fun readRedirectUriFromSnapshot(): String {
+        val ephemeral = client.currentSnapshot().ephemeralFlowState
         check(ephemeral is Snapshot.EphemeralAuthorizationCodeFlowState) {
             "Expected EphemeralAuthorizationCodeFlowState, got ${ephemeral?.let { it::class.simpleName }}"
         }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTokenResponseValidator.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/authorizationCode/AuthorizationCodeFlowTokenResponseValidator.kt
@@ -47,8 +47,8 @@ public class AuthorizationCodeFlowTokenResponseValidator(
         return decodeIdToken(rawIdToken)
     }
 
-    override fun validateIdTokenNonce(idToken: IdToken) {
-        require(idToken.nonce == client.snapshots.value.nonce) { "nonce mismatch" }
+    override suspend fun validateIdTokenNonce(idToken: IdToken) {
+        require(idToken.nonce == client.currentSnapshot().nonce) { "nonce mismatch" }
     }
 
     override suspend fun validateAuthTime(idToken: IdToken) {

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlow.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/flow/endSession/EndSessionFlow.kt
@@ -89,8 +89,10 @@ internal constructor(
     override fun createEphemeralFlowState(redirectUri: String): Snapshot.EphemeralFlowState =
         Snapshot.EphemeralEndSessionFlowState(state = state, responseUri = null)
 
-    override suspend fun onPrepare(redirectUri: String): String =
-        try {
+    override suspend fun onPrepare(redirectUri: String): String {
+        val idTokenHint = client.currentSnapshot().tokens?.idToken?.raw
+
+        return try {
             buildUrl {
                     takeFrom(endpoint)
 
@@ -99,10 +101,7 @@ internal constructor(
                     parameters[Parameter.CLIENT_ID] = client.id.value
 
                     addOptionalParameter(Parameter.UI_LOCALES, request.uiLocales)
-                    addOptionalParameter(
-                        Parameter.ID_TOKEN_HINT,
-                        client.snapshots.value.tokens?.idToken?.raw,
-                    )
+                    addOptionalParameter(Parameter.ID_TOKEN_HINT, idTokenHint)
                     addOptionalParameter(Parameter.LOGOUT_HINT, request.logoutHint)
                     addAdditionalParameters(request.additionalParameters)
                 }
@@ -114,6 +113,7 @@ internal constructor(
         } catch (e: Exception) {
             throw RequestException(e)
         }
+    }
 
     internal companion object {
 

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/refresh/RefreshTokenRequest.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/refresh/RefreshTokenRequest.kt
@@ -52,8 +52,8 @@ internal class RefreshTokenRequestImpl(
 ) : RefreshTokenRequest {
 
     override suspend operator fun invoke(): Response {
-        val refreshToken =
-            checkNotNull(client.snapshots.value.tokens?.refreshToken) { "refresh token is null" }
+        val currentTokens = client.currentSnapshot().tokens
+        val refreshToken = checkNotNull(currentTokens?.refreshToken) { "refresh token is null" }
 
         val response = tokenRequest {
             append(Parameter.GRANT_TYPE, GrantType.RefreshToken.value)
@@ -65,7 +65,7 @@ internal class RefreshTokenRequestImpl(
             try {
                 tokenResponseValidator.validate(
                     response = response,
-                    previousIdToken = client.snapshots.value.tokens?.idToken,
+                    previousIdToken = currentTokens.idToken,
                 )
             } catch (e: CancellationException) {
                 throw e

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/refresh/RefreshTokenResponseValidator.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/refresh/RefreshTokenResponseValidator.kt
@@ -26,10 +26,10 @@ internal class RefreshTokenResponseValidator(serializer: Json, client: InternalC
 
     override fun getIdToken(response: TokenResponse) = response.idToken?.let(::decodeIdToken)
 
-    override fun validateIdTokenNonce(idToken: IdToken) {
+    override suspend fun validateIdTokenNonce(idToken: IdToken) {
         // nonce is optional for a refresh response but if it's present it must be validated
         idToken.nonce?.let {
-            require(idToken.nonce == client.snapshots.value.nonce) { "nonce mismatch" }
+            require(idToken.nonce == client.currentSnapshot().nonce) { "nonce mismatch" }
         }
     }
 }

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenResponseValidator.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/request/token/TokenResponseValidator.kt
@@ -88,7 +88,7 @@ public abstract class TokenResponseValidator<T : IdToken?>(
 
     protected abstract fun getIdToken(response: TokenResponse): T
 
-    protected abstract fun validateIdTokenNonce(idToken: IdToken)
+    protected abstract suspend fun validateIdTokenNonce(idToken: IdToken)
 
     /**
      * This method is empty because the "auth_time" validation is only relevant for the

--- a/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/SnapshotStore.kt
+++ b/lib/lokksmith-core/src/commonMain/kotlin/dev/lokksmith/client/snapshot/SnapshotStore.kt
@@ -85,6 +85,17 @@ internal interface InternalSnapshotStore : SnapshotStore {
     /** This Mutex ensures that no concurrent write operations occur here and in [contract]. */
     val writeMutex: Mutex
 
+    /**
+     * Per-key [Mutex] registry backing [InternalClient.SnapshotContract.refreshMutex]. Lives here
+     * rather than on a [dev.lokksmith.client.Client] instance because [dev.lokksmith.Lokksmith.get]
+     * hands out a new [dev.lokksmith.client.ClientImpl] per call over the same store, so a
+     * client-owned Mutex would serialize nothing across those instances. Guarded by
+     * [refreshMutexRegistryLock] since the map itself is shared mutable state.
+     */
+    val refreshMutexes: MutableMap<Key, Mutex>
+
+    val refreshMutexRegistryLock: Mutex
+
     suspend fun internalSet(key: Key, snapshot: Snapshot): Snapshot {
         persistence.set(key, serializer.encodeToString(snapshot))
         return snapshot
@@ -97,6 +108,8 @@ internal class SnapshotStoreImpl(
 ) : InternalSnapshotStore {
 
     override val writeMutex = Mutex()
+    override val refreshMutexes: MutableMap<Key, Mutex> = mutableMapOf()
+    override val refreshMutexRegistryLock = Mutex()
 
     override fun observe(key: Key): Flow<Snapshot?> =
         persistence.observe(key).map { it?.let(serializer::decodeFromString) }
@@ -174,22 +187,32 @@ internal suspend fun InternalSnapshotStore.contract(
     // [coroutineScope] rather than to any caller.
     persistence.get(key)
 
-    val snapshots = observe(key).filterNotNull()
+    val snapshotsFlow = observe(key).filterNotNull()
 
     // A StateFlow already behaves like distinctUntilChanged() is applied, so we don't need to
     // explicitly use it here. We don't want this Flow to emit values if the underlying snapshot
     // changes but remains structurally equal.
-    val snapshotsStateFlow = snapshots.stateIn(coroutineScope)
+    val snapshotsStateFlow = snapshotsFlow.stateIn(coroutineScope)
+
+    // Resolved once per client creation so every Client instance created for this key (see
+    // refreshMutexes) shares the same Mutex object.
+    val keyRefreshMutex = refreshMutexRegistryLock.withLock {
+        refreshMutexes.getOrPut(key) { Mutex() }
+    }
 
     return object : InternalClient.SnapshotContract {
 
         override val snapshots: StateFlow<Snapshot> = snapshotsStateFlow
 
+        override val refreshMutex: Mutex = keyRefreshMutex
+
         override suspend fun updateSnapshot(body: Snapshot.() -> Snapshot) = writeMutex.withLock {
-            // We don't use `snapshotStateFlow.value` of the StateFlow at this point to fetch
+            // We don't use `snapshotsStateFlow.value` of the StateFlow at this point to fetch
             // the current value because since it collects in a different coroutine, swift
             // consecutive executions of `updateSnapshot` might see stale data.
-            internalSet(key, snapshots.first().body())
+            internalSet(key, snapshotsFlow.first().body())
         }
+
+        override suspend fun currentSnapshot(): Snapshot = snapshotsFlow.first()
     }
 }

--- a/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
+++ b/lib/lokksmith-core/src/commonTest/kotlin/dev/lokksmith/client/ClientTest.kt
@@ -56,7 +56,10 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Instant
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
@@ -68,6 +71,237 @@ import kotlinx.serialization.json.JsonPrimitive
 class ClientTest {
 
     private val httpJson = Json { prettyPrint = true }
+
+    /**
+     * A token endpoint that rotates refresh tokens: a grant carrying `token-N` is answered with
+     * `token-(N+1)`. Every submitted refresh token is appended to [sentRefreshTokens] in order.
+     * When [gateFirstRequest] is given, the very first request that reaches the engine suspends
+     * until it completes, so a caller can prove a second request started while the first was still
+     * in flight.
+     */
+    private fun rotatingRefreshTokenEngine(
+        sentRefreshTokens: MutableList<String>,
+        nonce: String,
+        epochSeconds: Long,
+        gateFirstRequest: CompletableDeferred<Unit>? = null,
+    ): MockEngine {
+        val jwtEncoder = JwtEncoder(Json)
+        var requestCount = 0
+
+        return MockEngine { request ->
+            when (request.url.toString()) {
+                "https://example.com/tokenEndpoint" -> {
+                    val body = assertIs<FormDataContent>(request.body)
+                    val refreshToken = assertNotNull(body.formData[Parameter.REFRESH_TOKEN])
+                    sentRefreshTokens += refreshToken
+
+                    val isFirstRequest = requestCount == 0
+                    requestCount++
+                    if (isFirstRequest) {
+                        gateFirstRequest?.await()
+                    }
+
+                    val nextRefreshToken =
+                        "token-${refreshToken.substringAfter("token-").toInt() + 1}"
+                    val idToken =
+                        Jwt(
+                            header = Jwt.Header(alg = "none"),
+                            payload =
+                                Jwt.Payload(
+                                    iss = "issuer",
+                                    sub = "8582ce26-3994-42e7-afb0-39d42e18fd1f",
+                                    aud = listOf("clientId"),
+                                    exp = epochSeconds + 600,
+                                    iat = epochSeconds,
+                                    extra = mapOf("nonce" to JsonPrimitive(nonce)),
+                                ),
+                        )
+                    val response =
+                        TokenResponse(
+                            tokenType = "Bearer",
+                            accessToken = "access-token",
+                            expiresIn = 600,
+                            refreshToken = nextRefreshToken,
+                            idToken = jwtEncoder.encode(idToken),
+                        )
+
+                    respond(
+                        content = httpJson.encodeToString(response),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+                else -> respondBadRequest()
+            }
+        }
+    }
+
+    @Test
+    fun `refresh should not send an already-rotated refresh token when called concurrently`() =
+        runTest {
+            val sentRefreshTokens = mutableListOf<String>()
+            val gate = CompletableDeferred<Unit>()
+            val engine =
+                rotatingRefreshTokenEngine(
+                    sentRefreshTokens = sentRefreshTokens,
+                    nonce = "0D1ck61",
+                    epochSeconds = 1748706999,
+                    gateFirstRequest = gate,
+                )
+
+            val client =
+                createTestClient(
+                    provider =
+                        TestProvider(
+                            httpClient = createHttpClient(engine),
+                            timeProvider = { Instant.fromEpochSeconds(1748706999, 0) },
+                        ),
+                    initialSnapshot = {
+                        copy(
+                            tokens =
+                                SAMPLE_TOKENS.copy(
+                                    refreshToken =
+                                        Tokens.RefreshToken(token = "token-0", expiresAt = null)
+                                ),
+                            nonce = "0D1ck61",
+                        )
+                    },
+                )
+
+            val first = async { client.refresh() }
+            val second = async { client.refresh() }
+            runCurrent()
+
+            gate.complete(Unit)
+            runCurrent()
+            awaitAll(first, second)
+
+            assertEquals(
+                listOf("token-0", "token-1"),
+                sentRefreshTokens,
+                "the second refresh must send the rotated token, not replay the first grant",
+            )
+        }
+
+    @Test
+    fun `refresh must not be replayed by a stale sibling client sharing the same snapshot store`() =
+        runTest {
+            val key = "key".asKey()
+            val sentRefreshTokens = mutableListOf<String>()
+            val engine =
+                rotatingRefreshTokenEngine(
+                    sentRefreshTokens = sentRefreshTokens,
+                    nonce = "0D1ck61",
+                    epochSeconds = 1748706999,
+                )
+            val sharedStore = SnapshotStoreImpl(persistence = PersistenceFake(), serializer = Json)
+            val provider =
+                TestProvider(
+                    httpClient = createHttpClient(engine),
+                    timeProvider = { Instant.fromEpochSeconds(1748706999, 0) },
+                )
+
+            // Lokksmith.get() hands out a new Client instance per call over the same
+            // SnapshotStore, so clientA and clientB model two such instances for the same key.
+            val clientA =
+                createTestClient(
+                    key = key,
+                    snapshotStore = sharedStore,
+                    provider = provider,
+                    initialSnapshot = {
+                        copy(
+                            tokens =
+                                SAMPLE_TOKENS.copy(
+                                    refreshToken =
+                                        Tokens.RefreshToken(token = "token-0", expiresAt = null)
+                                ),
+                            nonce = "0D1ck61",
+                        )
+                    },
+                )
+            val clientB =
+                ClientImpl.create(
+                    key = key,
+                    options = Client.Options(),
+                    coroutineScope = backgroundScope,
+                    snapshotStore = sharedStore,
+                    provider = provider,
+                )
+
+            clientA.refresh()
+            // No runCurrent() here: clientB's cached snapshot must not have observed clientA's
+            // write yet, which is exactly the scenario that must not leak onto the wire.
+            clientB.refresh()
+            runCurrent()
+
+            assertEquals(
+                listOf("token-0", "token-1"),
+                sentRefreshTokens,
+                "clientB must send the rotated token, not replay clientA's already-used grant",
+            )
+        }
+
+    @Test
+    fun `concurrent refresh must be serialized across sibling clients of the same key`() = runTest {
+        val key = "key".asKey()
+        val sentRefreshTokens = mutableListOf<String>()
+        val gate = CompletableDeferred<Unit>()
+        val engine =
+            rotatingRefreshTokenEngine(
+                sentRefreshTokens = sentRefreshTokens,
+                nonce = "0D1ck61",
+                epochSeconds = 1748706999,
+                gateFirstRequest = gate,
+            )
+        val sharedStore = SnapshotStoreImpl(persistence = PersistenceFake(), serializer = Json)
+        val provider =
+            TestProvider(
+                httpClient = createHttpClient(engine),
+                timeProvider = { Instant.fromEpochSeconds(1748706999, 0) },
+            )
+
+        val clientA =
+            createTestClient(
+                key = key,
+                snapshotStore = sharedStore,
+                provider = provider,
+                initialSnapshot = {
+                    copy(
+                        tokens =
+                            SAMPLE_TOKENS.copy(
+                                refreshToken =
+                                    Tokens.RefreshToken(token = "token-0", expiresAt = null)
+                            ),
+                        nonce = "0D1ck61",
+                    )
+                },
+            )
+        val clientB =
+            ClientImpl.create(
+                key = key,
+                options = Client.Options(),
+                coroutineScope = backgroundScope,
+                snapshotStore = sharedStore,
+                provider = provider,
+            )
+
+        // Pins that the refresh Mutex is resolved from the store's per-key registry rather than
+        // owned by a client: a Mutex per ClientImpl would let these two instances race.
+        val first = async { clientA.refresh() }
+        val second = async { clientB.refresh() }
+        runCurrent()
+
+        gate.complete(Unit)
+        runCurrent()
+        awaitAll(first, second)
+
+        assertEquals(
+            listOf("token-0", "token-1"),
+            sentRefreshTokens,
+            "clientB must wait for clientA's refresh and then send the rotated token",
+        )
+    }
 
     @Test
     fun `refresh should refresh tokens`() = runTest {


### PR DESCRIPTION
## TL;DR

`RefreshTokenRequestImpl` read the refresh token to send from `client.snapshots`, a StateFlow whose collector runs on another coroutine, so a refresh starting before that collector caught up replayed the token the previous refresh had already spent. Every read that decides what goes on the wire now goes to the store instead, via a new `InternalClient.currentSnapshot()`, and `refresh()` holds a per-key mutex across read, request and write.

Closes #517

## What was stale

Beyond the refresh grant itself, the same `snapshots.value` pattern decided wire content in five more places, all fixed here: the previous ID token passed to validation, both nonce checks, the `id_token_hint` on the authorization and end session requests, and the ephemeral redirect URI read back after a redirect. `TokenResponseValidator.validateIdTokenNonce` became `suspend` as a result, which changes the ABI dumps.

`client.tokens` and `client.snapshots` keep their reactive, lagging semantics. They are for observation, which `Client.tokens` already documents.

## The mutex

It lives on `SnapshotStore` rather than on the client because `Lokksmith.get()` hands out a new `Client` instance per call over the same store, so a client-owned mutex would serialize nothing across them. It is deliberately not `writeMutex`: `updateSnapshot` takes that one, so reusing it would deadlock, and it would block unrelated clients' writes for the length of a network call.

No request coalescing. The second caller waits and then issues its own request with the rotated token, which is what `refresh()` documents. Two concurrent `runWithTokens` on an expired token will each refresh, the second one redundantly. Correct but wasteful, worth a follow-up if it shows up.

## Testing

Three regression tests in `ClientTest.kt`, each confirmed to fail before the fix:

1. Concurrent `refresh()` on one client.
2. Sequential `refresh()` across two sibling clients over one store, without letting the collector run in between.
3. Concurrent `refresh()` across two sibling clients. This one pins the mutex being resolved from the store's per-key registry, and is the only test that fails if it is replaced with a per-client `Mutex()`.

```
cd lib && ./gradlew :lokksmith-core:jvmTest --tests "*ClientTest*"
cd lib && ./gradlew check
```

`check` fails locally at `:lokksmith-core:wasmJsBrowserTest` with `No binary for ChromeHeadless browser`. That reproduces on an unmodified `main` here, so it looks environmental rather than related to this change.

Not verifiable by hand against the demo app: the window is sub-millisecond and the local OIDC setup does not invalidate a reused refresh token, which is why the reporter only saw it in a unit test.

The code in this PR was generated by an LLM (Claude Code, Claude Opus 5).
