### PR TITLE
feat(swift): publish the Swift package via SPM

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,0 +1,30 @@
+name: Setup Gradle
+description: Installs the JDK and restores the Gradle and Kotlin/Native caches for a Gradle build root.
+
+inputs:
+  project-directory:
+    description: Gradle build root the caches are keyed on, for example lib or demo.
+    required: false
+    default: lib
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v6
+      with:
+        distribution: temurin
+        java-version: 21
+        cache: "gradle"
+        cache-dependency-path: |
+          ${{ inputs.project-directory }}/**/*.gradle*
+          ${{ inputs.project-directory }}/**/gradle-wrapper.properties
+          ${{ inputs.project-directory }}/gradle/*.versions.toml
+
+    # Kotlin/Native downloads a compiler distribution and builds klib caches per Kotlin version, so
+    # this is keyed on the same files as the Gradle cache.
+    - name: Cache konan
+      uses: actions/cache@v6
+      with:
+        path: ~/.konan
+        key: ${{ runner.os }}-konan-${{ hashFiles(format('{0}/**/*.gradle*', inputs.project-directory), format('{0}/gradle/*.versions.toml', inputs.project-directory)) }}
+        restore-keys: ${{ runner.os }}-konan

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,7 +12,8 @@
         { "type": "deps", "section": "Dependencies" },
         { "type": "docs", "section": "Documentation", "hidden": true },
         { "type": "chore", "section": "Chores", "hidden": true }
-      ]
+      ],
+      "extra-files": [{ "type": "generic", "path": "Package.swift" }]
     }
   }
 }

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,21 +19,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: 'gradle'
-          cache-dependency-path: |
-            lib/**/*.gradle*
-            lib/**/gradle-wrapper.properties
-            lib/gradle/*.versions.toml
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+      - uses: ./.github/actions/setup-gradle
       - name: Create snapshot VERSION
         run: echo "VERSION=$(git describe --tags --abbrev=0 --match="v*" | sed 's/^v//')-SNAPSHOT" >> $GITHUB_ENV
       - name: Publish snapshot release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,21 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: "gradle"
-          cache-dependency-path: |
-            lib/**/*.gradle*
-            lib/**/gradle-wrapper.properties
-            lib/gradle/*.versions.toml
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+      - uses: ./.github/actions/setup-gradle
       - name: Strip leading v from VERSION
         run: echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
         env:
@@ -45,23 +31,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: "gradle"
-          cache-dependency-path: |
-            lib/**/*.gradle*
-            lib/**/gradle-wrapper.properties
-            lib/gradle/*.versions.toml
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+      - uses: ./.github/actions/setup-gradle
+      # Must match the version the release PR built with, since it is compiled into the binary and
+      # therefore into the checksum. Read from the same source as swift-package.yml rather than from
+      # the tag name, so the two cannot drift apart.
+      - name: Read the released version
+        run: echo "VERSION=$(jq -r '."."' .github/.release-please-manifest.json)" >> "$GITHUB_ENV"
       - name: Build the XCFramework archive
-        run: ./gradlew :lokksmith-swift:packageSwiftArtifact
+        run: ./gradlew :lokksmith-swift:packageSwiftArtifact -PVERSION_NAME="$VERSION"
         working-directory: ./lib
       # Package.swift is already tagged and cannot be corrected, so a mismatch means every consumer
       # of this version would get a checksum error from SPM. Fail before the asset is attached, so

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,10 @@ jobs:
         run: |
           sed -i "s|^lokksmith_version = .*|lokksmith_version = \"$VERSION\"|" ./site/zensical.toml
           sed -i "s|^lokksmith_version_date = .*|lokksmith_version_date = \"$(date -u "+%b %d, %Y")\"|" ./site/zensical.toml
+          # The Swift package is available from this release on, so the "not available yet" note
+          # comes out. The markers make this a precise range delete, and once they are gone this
+          # is a no-op on every later release.
+          sed -i '/<!-- swift-package-pending -->/,/<!-- \/swift-package-pending -->/d' ./site/docs/getting-started/installation.md
       - name: Create PR for documentation
         uses: peter-evans/create-pull-request@v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,58 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
         working-directory: ./lib
 
+  swift-package:
+    timeout-minutes: 30
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: "gradle"
+          cache-dependency-path: |
+            lib/**/*.gradle*
+            lib/**/gradle-wrapper.properties
+            lib/gradle/*.versions.toml
+      - name: Cache konan
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
+          restore-keys: ${{ runner.os }}-konan
+      - name: Build the XCFramework archive
+        run: ./gradlew :lokksmith-swift:packageSwiftArtifact
+        working-directory: ./lib
+      # Package.swift is already tagged and cannot be corrected, so a mismatch means every consumer
+      # of this version would get a checksum error from SPM. Fail before the asset is attached, so
+      # the failure is one red release job rather than a broken package.
+      - name: Verify the tagged Package.swift describes this release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          BUILT=$(shasum -a 256 lib/lokksmith-swift/build/swift/archive/Lokksmith.xcframework.zip | cut -d' ' -f1)
+          TAGGED=$(grep -oE 'checksum: "[a-f0-9]{64}"' Package.swift | cut -d'"' -f2)
+          if [ "$BUILT" != "$TAGGED" ]; then
+            echo "::error::Archive checksum $BUILT does not match $TAGGED in the tagged Package.swift."
+            exit 1
+          fi
+
+          # Catches the version in the download URL not having been updated, which would otherwise
+          # point consumers of this tag at the previous release's asset.
+          if ! grep -q "releases/download/$TAG/Lokksmith.xcframework.zip" Package.swift; then
+            echo "::error::Package.swift does not point at $TAG. Found:"
+            grep -oE 'url: "[^"]+"' Package.swift >&2
+            exit 1
+          fi
+      - name: Attach the archive to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            lib/lokksmith-swift/build/swift/archive/Lokksmith.xcframework.zip \
+            --repo "${{ github.repository }}" --clobber
+
   documentation:
     needs: publish
     timeout-minutes: 15

--- a/.github/workflows/pull-request-demo.yml
+++ b/.github/workflows/pull-request-demo.yml
@@ -12,21 +12,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6
+      - uses: ./.github/actions/setup-gradle
         with:
-          distribution: temurin
-          java-version: 21
-          cache: 'gradle'
-          cache-dependency-path: |
-            demo/**/*.gradle*
-            demo/**/gradle-wrapper.properties
-            demo/gradle/*.versions.toml
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('demo/**/*.gradle*', 'demo/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+          project-directory: demo
       - run: ./gradlew check
         working-directory: ./demo
       - name: Store reports

--- a/.github/workflows/pull-request-demo.yml
+++ b/.github/workflows/pull-request-demo.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - 'demo/**'
+      - '.github/actions/**'
   workflow_dispatch:
 jobs:
   check:

--- a/.github/workflows/pull-request-lib.yml
+++ b/.github/workflows/pull-request-lib.yml
@@ -12,21 +12,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: 'gradle'
-          cache-dependency-path: |
-            lib/**/*.gradle*
-            lib/**/gradle-wrapper.properties
-            lib/gradle/*.versions.toml
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew check checkKotlinAbi
         working-directory: ./lib
       - name: Store reports

--- a/.github/workflows/pull-request-lib.yml
+++ b/.github/workflows/pull-request-lib.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - 'lib/**'
+      - '.github/actions/**'
   workflow_dispatch:
 jobs:
   check:

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -39,44 +39,44 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: 21
-          cache: "gradle"
-          cache-dependency-path: |
-            lib/**/*.gradle*
-            lib/**/gradle-wrapper.properties
-            lib/gradle/*.versions.toml
+      - uses: ./.github/actions/setup-gradle
 
-      - name: Cache konan
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
-          restore-keys: ${{ runner.os }}-konan
+      # The version is compiled into the binary through the default user agent, so it changes the
+      # archive's checksum. It must be the same here and in the publish job, or the checksum stamped
+      # now would not match the one verified at the tag. The manifest is bumped inside this very
+      # release PR, so it already holds the version being released.
+      - name: Read the version being released
+        run: echo "VERSION=$(jq -r '."."' .github/.release-please-manifest.json)" >> "$GITHUB_ENV"
 
       - name: Build the XCFramework archive
-        run: ./gradlew :lokksmith-swift:packageSwiftArtifact
+        run: ./gradlew :lokksmith-swift:packageSwiftArtifact -PVERSION_NAME="$VERSION"
         working-directory: ./lib
 
       # release-please force-pushes this branch whenever it regenerates the release PR, which drops
-      # the stamped commit. This workflow runs again on that push, so the branch converges.
-      - name: Stamp the checksum into Package.swift
+      # the stamped commit. This workflow runs again on that push, so the branch converges. The
+      # `cancel-in-progress` concurrency above matters here: a force-push mid-build cancels the run
+      # that would otherwise push a checksum for the previous content.
+      #
+      # The URL version is normally bumped by release-please's `extra-files`. It is stamped here as
+      # well so the manifest is correct even if that does not happen, because at this point it can
+      # still be fixed. Once the tag exists it cannot.
+      - name: Stamp the version and checksum into Package.swift
         run: |
           BUILT=$(shasum -a 256 lib/lokksmith-swift/build/swift/archive/Lokksmith.xcframework.zip | cut -d' ' -f1)
-          COMMITTED=$(grep -oE 'checksum: "[a-f0-9]{64}"' Package.swift | cut -d'"' -f2)
-          echo "Built:     $BUILT"
-          echo "Committed: $COMMITTED"
 
-          if [ "$BUILT" = "$COMMITTED" ]; then
-            echo "Package.swift is already up to date."
+          sed -i '' -E \
+            -e "s|releases/download/v[0-9][^/]*/|releases/download/v$VERSION/|" \
+            -e "s|checksum: \"[a-f0-9]{64}\"|checksum: \"$BUILT\"|" \
+            Package.swift
+
+          if git diff --quiet Package.swift; then
+            echo "Package.swift already describes v$VERSION with checksum $BUILT."
             exit 0
           fi
 
-          sed -i '' -E "s|checksum: \"[a-f0-9]{64}\"|checksum: \"$BUILT\"|" Package.swift
+          git diff Package.swift
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Package.swift
-          git commit -m "chore: update Swift package checksum"
+          git commit -m "chore: update Swift package manifest for v$VERSION"
           git push

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -7,9 +7,10 @@ name: Swift Package
 # Between releases the committed checksum describes the previous release and does not match what
 # main builds. That is expected, so nothing is verified here outside the release PR.
 
+# The default token only reads the repository. The checkout and the push back to the release PR
+# use the GitHub App token instead, so a push re-triggers this workflow's checks.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/swift-package.yml
+++ b/.github/workflows/swift-package.yml
@@ -1,0 +1,82 @@
+name: Swift Package
+
+# Swift Package Manager reads Package.swift at the git tag, so the binary target's checksum has to
+# be correct *before* the release is tagged. release-please tags when its release PR is merged, so
+# the checksum is stamped into that PR while it is still open.
+#
+# Between releases the committed checksum describes the previous release and does not match what
+# main builds. That is expected, so nothing is verified here outside the release PR.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  checksum:
+    if: startsWith(github.head_ref, 'release-please--')
+    timeout-minutes: 30
+    runs-on: macos-latest
+    steps:
+      # A GitHub App token is required to push back to the release PR: a push made with the default
+      # GITHUB_TOKEN does not re-trigger that pull request's checks.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: "gradle"
+          cache-dependency-path: |
+            lib/**/*.gradle*
+            lib/**/gradle-wrapper.properties
+            lib/gradle/*.versions.toml
+
+      - name: Cache konan
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('lib/**/*.gradle*', 'lib/gradle/*.versions.toml') }}
+          restore-keys: ${{ runner.os }}-konan
+
+      - name: Build the XCFramework archive
+        run: ./gradlew :lokksmith-swift:packageSwiftArtifact
+        working-directory: ./lib
+
+      # release-please force-pushes this branch whenever it regenerates the release PR, which drops
+      # the stamped commit. This workflow runs again on that push, so the branch converges.
+      - name: Stamp the checksum into Package.swift
+        run: |
+          BUILT=$(shasum -a 256 lib/lokksmith-swift/build/swift/archive/Lokksmith.xcframework.zip | cut -d' ' -f1)
+          COMMITTED=$(grep -oE 'checksum: "[a-f0-9]{64}"' Package.swift | cut -d'"' -f2)
+          echo "Built:     $BUILT"
+          echo "Committed: $COMMITTED"
+
+          if [ "$BUILT" = "$COMMITTED" ]; then
+            echo "Package.swift is already up to date."
+            exit 0
+          fi
+
+          sed -i '' -E "s|checksum: \"[a-f0-9]{64}\"|checksum: \"$BUILT\"|" Package.swift
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          git commit -m "chore: update Swift package checksum"
+          git push

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+// Lokksmith for native iOS apps.
+//
+// Kotlin Multiplatform and Compose Multiplatform applications depend on `dev.lokksmith:lokksmith-core`
+// through Gradle instead.
+//
+// Both values below are maintained by automation and should not be edited by hand:
+//   - the version in `url` is updated by release-please,
+//   - `checksum` is stamped by .github/workflows/swift-package.yml while the release PR is open,
+//     so that it is already correct at the tag SPM resolves.
+let package = Package(
+    name: "Lokksmith",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "Lokksmith",
+            targets: ["Lokksmith"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Lokksmith",
+            url: "https://github.com/svenjacobs/lokksmith/releases/download/v2.1.1/Lokksmith.xcframework.zip", // x-release-please-version
+            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+        )
+    ]
+)

--- a/lib/lokksmith-swift/build.gradle.kts
+++ b/lib/lokksmith-swift/build.gradle.kts
@@ -1,5 +1,4 @@
 import java.security.MessageDigest
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -21,13 +20,13 @@ kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
     abiValidation()
 
-    val xcframework = XCFramework(frameworkName)
-
+    // No XCFramework is registered here on purpose. `createSwiftXCFramework` assembles the
+    // published one from these per-target frameworks, because the plugin's `assembleXCFramework`
+    // is not reproducible and SPM pins the archive by checksum.
     listOf(iosArm64(), iosSimulatorArm64()).forEach { target ->
         target.binaries.framework {
             baseName = frameworkName
             isStatic = true
-            xcframework.add(this)
         }
     }
 

--- a/lib/lokksmith-swift/build.gradle.kts
+++ b/lib/lokksmith-swift/build.gradle.kts
@@ -107,30 +107,99 @@ if (HostManager.hostIsMac) {
 }
 
 /**
+ * Assembles the XCFramework that is published to Swift Package Manager.
+ *
+ * SPM pins the archive by checksum, so the same source must always produce the same bytes. The
+ * slice binaries already are identical between builds, but `xcodebuild -create-xcframework` writes
+ * `AvailableLibraries` in a non-deterministic order, which alone changes the checksum. It ignores
+ * argument order, so the entries are sorted afterwards. `sort_keys` also fixes the key order within
+ * each entry.
+ *
+ * The Kotlin plugin's `assembleXCFramework` is not used here because its output cannot be
+ * normalised without rewriting a file the plugin owns.
+ */
+val createSwiftXCFramework =
+    if (HostManager.hostIsMac) {
+        tasks.register<Exec>("createSwiftXCFramework") {
+            group = "publishing"
+            description = "Assembles a reproducible $frameworkName XCFramework."
+
+            val slices =
+                listOf("IosArm64" to "iosArm64", "IosSimulatorArm64" to "iosSimulatorArm64")
+            slices.forEach { (taskSuffix, _) -> dependsOn("linkReleaseFramework$taskSuffix") }
+
+            val frameworks =
+                slices.map { (_, targetDir) ->
+                    layout.buildDirectory.dir(
+                        "bin/$targetDir/releaseFramework/$frameworkName.framework"
+                    )
+                }
+            val output = layout.buildDirectory.dir("swift/$frameworkName.xcframework")
+
+            frameworks.forEach { inputs.dir(it) }
+            outputs.dir(output)
+
+            val outputPath = output.get().asFile.absolutePath
+            val frameworkArgs =
+                frameworks.joinToString(" ") { "-framework '${it.get().asFile.absolutePath}'" }
+
+            commandLine(
+                "bash",
+                "-euo",
+                "pipefail",
+                "-c",
+                """
+                rm -rf '$outputPath'
+                xcrun xcodebuild -create-xcframework $frameworkArgs -output '$outputPath'
+                python3 - '$outputPath/Info.plist' <<'PY'
+                import plistlib, sys
+                path = sys.argv[1]
+                with open(path, 'rb') as f:
+                    plist = plistlib.load(f)
+                plist['AvailableLibraries'].sort(key=lambda library: library['LibraryIdentifier'])
+                with open(path, 'wb') as f:
+                    plistlib.dump(plist, f, sort_keys=True)
+                PY
+                """
+                    .trimIndent(),
+            )
+        }
+    } else {
+        null
+    }
+
+/**
  * Archives the XCFramework for Swift Package Manager and prints its checksum.
  *
  * SPM expects the SHA-256 of the archive, which is what `swift package compute-checksum` returns.
- * Nothing consumes this yet: the `Package.swift` that references the archive, and the release
- * automation that attaches it and stamps the checksum, follow separately.
+ * The release workflow stamps this checksum into `Package.swift` before the tag is created, so the
+ * archive must be byte-identical every time it is built from the same source.
  */
-tasks.register<Zip>("packageSwiftArtifact") {
-    group = "publishing"
-    description = "Archives the $frameworkName XCFramework for Swift Package Manager."
+if (createSwiftXCFramework != null) {
+    tasks.register<Zip>("packageSwiftArtifact") {
+        group = "publishing"
+        description = "Archives the $frameworkName XCFramework for Swift Package Manager."
 
-    dependsOn("assemble${frameworkName}ReleaseXCFramework")
+        dependsOn(createSwiftXCFramework)
 
-    from(layout.buildDirectory.dir("XCFrameworks/release"))
-    archiveFileName = "$frameworkName.xcframework.zip"
-    destinationDirectory = layout.buildDirectory.dir("swift")
+        from(layout.buildDirectory.dir("swift")) { include("$frameworkName.xcframework/**") }
+        archiveFileName = "$frameworkName.xcframework.zip"
+        destinationDirectory = layout.buildDirectory.dir("swift/archive")
 
-    val archive = destinationDirectory.file("$frameworkName.xcframework.zip")
-    doLast {
-        val bytes = archive.get().asFile.readBytes()
-        val checksum =
-            MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { byte ->
-                "%02x".format(byte)
-            }
-        logger.lifecycle("Archive:  ${archive.get().asFile}")
-        logger.lifecycle("Checksum: $checksum")
+        // SPM pins the archive by checksum, so the same inputs must always produce the same bytes.
+        // Without these, entry order and file timestamps vary between builds.
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+
+        val archive = destinationDirectory.file("$frameworkName.xcframework.zip")
+        doLast {
+            val bytes = archive.get().asFile.readBytes()
+            val checksum =
+                MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { byte ->
+                    "%02x".format(byte)
+                }
+            logger.lifecycle("Archive:  ${archive.get().asFile}")
+            logger.lifecycle("Checksum: $checksum")
+        }
     }
 }

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -138,11 +138,13 @@ Native iOS apps consume Lokksmith as a binary Swift package. The package ships a
 from the `lokksmith-swift` module, which exposes a Swift-facing API over `lokksmith-core`. No Kotlin
 toolchain or Gradle build is involved.
 
+<!-- swift-package-pending -->
 !!! warning "Not available yet"
     The Swift package ships from the **next** release onwards. Earlier tags carry no `Package.swift`
     and no release asset, so Swift Package Manager cannot resolve them, and the version shown below
     is the currently released one rather than the first that will work.
 
+<!-- /swift-package-pending -->
 In Xcode, choose **File → Add Package Dependencies…** and enter:
 
 ```

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -3,6 +3,11 @@
 Lokksmith is distributed via Maven Central. We recommend using [Gradle Version Catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html)
 for dependency management.
 
+!!! info
+    Building a **native iOS app** in Swift, without Kotlin? Skip to
+    [Native iOS (Swift Package Manager)](#native-ios-swift-package-manager). The rest of this page
+    covers the Gradle setup for Kotlin Multiplatform projects.
+
 ## Add Lokksmith to Version Catalog
 
 Add the current version of Lokksmith to your `gradle/libs.versions.toml`:
@@ -126,5 +131,58 @@ Lokksmith uses Kotlin Serialization internally and depends on the ProGuard confi
 Usually this configuration is applied automatically. However, if you manually configure ProGuard
 you must ensure to apply the Kotlin Serialization rules or else Lokksmith will fail at
 (de)serialization.
+
+## Native iOS (Swift Package Manager)
+
+Native iOS apps consume Lokksmith as a binary Swift package. The package ships an XCFramework built
+from the `lokksmith-swift` module, which exposes a Swift-facing API over `lokksmith-core`. No Kotlin
+toolchain or Gradle build is involved.
+
+In Xcode, choose **File → Add Package Dependencies…** and enter:
+
+```
+https://github.com/svenjacobs/lokksmith
+```
+
+Or add it to your own `Package.swift`:
+
+```swift title="Package.swift"
+dependencies: [
+    .package(url: "https://github.com/svenjacobs/lokksmith", from: "{{ lokksmith_version }}")
+],
+targets: [
+    .target(
+        name: "MyApp",
+        dependencies: [.product(name: "Lokksmith", package: "lokksmith")]
+    )
+]
+```
+
+Requires iOS 15 or later. The framework is static, so nothing needs to be embedded or signed, and no
+extra system frameworks need to be linked.
+
+### Register the Redirect Scheme
+
+The redirect URI's scheme must be registered by your app, so that
+[`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession)
+can hand the response back. Add it to your `Info.plist`:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>my-app</string>
+        </array>
+    </dict>
+</array>
+```
+
+Lokksmith derives the callback scheme from the `redirectUri` you pass to the request, so no further
+configuration is needed. You do not need to handle the redirect in `onOpenURL` or
+`application(_:open:options:)`, as `ASWebAuthenticationSession` delivers it directly.
+
+Continue with [Usage → iOS](usage.md#ios).
 
 *[OIDC]: OpenID Connect

--- a/site/docs/getting-started/installation.md
+++ b/site/docs/getting-started/installation.md
@@ -138,6 +138,11 @@ Native iOS apps consume Lokksmith as a binary Swift package. The package ships a
 from the `lokksmith-swift` module, which exposes a Swift-facing API over `lokksmith-core`. No Kotlin
 toolchain or Gradle build is involved.
 
+!!! warning "Not available yet"
+    The Swift package ships from the **next** release onwards. Earlier tags carry no `Package.swift`
+    and no release asset, so Swift Package Manager cannot resolve them, and the version shown below
+    is the currently released one rather than the first that will work.
+
 In Xcode, choose **File → Add Package Dependencies…** and enter:
 
 ```

--- a/site/docs/getting-started/usage.md
+++ b/site/docs/getting-started/usage.md
@@ -203,15 +203,101 @@ the user interface accordingly or use `Client.authFlowResult`(1) from your busin
 
 ### iOS
 
-The iOS integration is currently usable from a Kotlin Multiplatform or Compose Multiplatform
-application. A dedicated Swift package for use in a native iOS app is still pending.
-
 To launch an authentication flow from the iOS platform code of a Kotlin Multiplatform application,
 use `launchAuthFlow()`:
 
 ```kotlin
 lokksmith.launchAuthFlow(initiation)
 ```
+
+#### Native iOS apps
+
+Native iOS apps written in Swift use the `Lokksmith` Swift package described in
+[Installation](installation.md#native-ios-swift-package-manager). It exposes a Swift-facing API
+rather than the Kotlin one: suspending functions become `async`, and the browser flow, code exchange
+and token persistence happen in a single call.
+
+Create one `LokksmithManager` for the lifetime of the app and share it:
+
+```swift
+import Lokksmith
+
+let lokksmith = LokksmithManager()
+
+let client = try await lokksmith.getOrCreateClient(
+    key: "main",
+    configuration: .companion.discovery(
+        clientId: "my-client-id",
+        discoveryUrl: "https://example.com/.well-known/openid-configuration"
+    )
+)
+```
+
+`authorize` presents an `ASWebAuthenticationSession`, exchanges the authorization code, validates
+the tokens and persists them. It returns `nil` when the user dismisses the browser:
+
+```swift
+let request = LokksmithAuthorizationRequest(redirectUri: "my-app://openid-response")
+request.scopes = ["profile", "email"]
+request.prompts = [.login] // optional, forces re-authentication
+
+if let tokens = try await client.authorize(request: request) {
+    print(tokens.accessToken.token)
+}
+```
+
+!!! note
+    Objective-C interop does not carry Kotlin default arguments, so optional request values are set
+    as properties rather than passed to the initializer.
+
+Reading the current tokens does not suspend and never triggers a network request, which makes it
+suitable for answering "is the user signed in?" synchronously:
+
+```swift
+if client.isAuthenticated { … }
+let subject = client.tokens?.idToken.subject
+```
+
+On the request path, use `freshTokens()`. It refreshes only when the access token or the ID token is
+expired or about to expire:
+
+```swift
+let accessToken = try await client.freshTokens().accessToken.token
+```
+
+To react to token changes, for example to mirror the access token somewhere, observe them and cancel
+the returned handle when you are done:
+
+```swift
+let observation = client.observeTokens { tokens in
+    // Called on the main thread, starting with the current value.
+}
+// later
+observation.cancel()
+```
+
+!!! warning
+    Errors cross the Objective-C boundary as `NSError`. Unwrap `LokksmithFailure` to find out what
+    went wrong. The distinction that matters is `oAuthRejection`, which means the provider rejected
+    the grant and the session is dead, versus `transport`, which is transient and should **not**
+    sign the user out:
+
+    ```swift
+    do {
+        let tokens = try await client.freshTokens()
+    } catch let error as NSError {
+        let failure = error.userInfo["KotlinException"] as? LokksmithFailure
+        switch failure?.kind {
+        case .oAuthRejection: try await client.resetTokens()
+        case .transport:      break // keep the session, retry later
+        default:              break
+        }
+    }
+    ```
+
+Local sign-out is `resetTokens()`, which discards the persisted tokens but keeps the client and its
+provider configuration. `endSession(request:)` additionally runs the provider's RP-initiated logout
+flow, when one is advertised.
 
 ### Desktop
 


### PR DESCRIPTION
Follow-up to #495. Adds `Package.swift`, the release automation that makes it resolve, and restores the installation and usage docs.

**Why the checksum is stamped before the tag.** SPM reads `Package.swift` at the git tag and pins the binary target by checksum. A post-release update, like the `documentation` job does, would leave the manifest at tag `vN` describing `vN-1`'s asset, and consumers would silently resolve the previous binary rather than see an error. So `swift-package.yml` stamps the checksum into release-please's PR while it is open; the version in the URL is handled by release-please `extra-files`. `publish.yml` then rebuilds, verifies against the tagged manifest, and only then attaches the asset.

**That needed a reproducibility fix.** Two clean builds of identical source alternated between two checksums. The binaries are identical; `xcodebuild -create-xcframework` writes `AvailableLibraries` in a non-deterministic order, and it ignores the order the `-framework` arguments come in. The entries are now sorted after creation, so three clean builds give one checksum. This is why packaging no longer uses the plugin's `assembleXCFramework`: its output cannot be normalised without rewriting a file the plugin owns.

**Two things for you to decide:**

- If the release PR is merged before the workflow finishes, the tag gets a stale checksum. The publish job catches it, but only after the tag exists. A required `Swift Package / checksum` check would prevent it; that is your repo setting, so I have not assumed it.
- If you would rather CI did not push to your release PR, the alternative is a separate `lokksmith-swift` repo tagged after the asset exists. No ordering problem, no pre-tag commit, at the cost of a second repo and a different package URL. Happy to switch.

**Verification.** Three clean builds produce one checksum, `swift package dump-package` parses the manifest, `swiftApiSmokeTest` / `spotlessCheck` / `checkKotlinAbi` pass, both workflows parse as YAML. Not verified end to end, as that needs a real release: the `extra-files` annotation and both workflow paths first run on the next release PR. Draft for that reason as much as any other.

---

Written with the help of Claude (Claude Code, Opus 5), directed and reviewed by me. The commit says the same.
